### PR TITLE
[Wip] 공통 컴포넌트 제작(5) UserList, (TextIconButton, MainHeader 수정사항 발생)

### DIFF
--- a/src/components/MainHeader/index.tsx
+++ b/src/components/MainHeader/index.tsx
@@ -9,56 +9,50 @@ import {
 } from '@chakra-ui/icons';
 import {
   Flex,
+  FlexProps,
   IconButton,
   Image,
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
 
-interface MainHeaderProps {
-  width?: number | string;
-  height?: number | string;
-}
-
-const MainHeader = ({
-  width = DEFAULT_WIDTH,
-  height = DEFAULT_HEADER_HEIGHT,
-}: MainHeaderProps) => {
+const MainHeader = ({ ...props }: FlexProps) => {
   const { toggleColorMode } = useColorMode();
   const DarkModeIcon = useColorModeValue(MoonIcon, SunIcon);
 
   return (
     <Flex
-      w={typeof width === 'string' ? width : `${width}px`}
-      h={typeof height === 'string' ? height : `${height}px`}
+      w={DEFAULT_WIDTH}
+      h={DEFAULT_HEADER_HEIGHT}
       justify="space-between"
       align="center"
+      {...props}
     >
       {/* 로고 들어갈 자리입니다. 로고 사이즈에 맞춰서 사용해주세요*/}
       <Image
         alt="dopen logo"
         w="130px"
-        h={typeof height === 'string' ? height : `${height}px`}
+        h={DEFAULT_HEADER_HEIGHT}
         src="https://via.placeholder.com/80"
       />
       <Flex gap="20px">
         <IconButton
           aria-label="toggleDarkMode"
           icon={<DarkModeIcon color="black" boxSize="icon" />}
-          bgColor="white"
+          bg="transparent"
           size="md"
           onClick={toggleColorMode}
         />
         <IconButton
           aria-label="message"
           icon={<ChatIcon color="black" boxSize="icon" />}
-          bgColor="white"
+          bg="transparent"
           size="md"
         />
         <IconButton
           aria-label="search"
           icon={<SearchIcon color="black" boxSize="icon" />}
-          bgColor="white"
+          bg="transparent"
           size="md"
         />
         <IconButton
@@ -68,7 +62,7 @@ const MainHeader = ({
               <BellIcon color="black" boxSize="icon" />
             </Badge>
           }
-          bgColor="white"
+          bg="transparent"
           size="md"
         />
       </Flex>

--- a/src/components/common/TextIconButton/index.tsx
+++ b/src/components/common/TextIconButton/index.tsx
@@ -12,7 +12,7 @@ const TextIconButton = ({ TheIcon, textContent }: TextIconButtonProps) => {
       <IconButton
         aria-label="home"
         icon={<Icon as={TheIcon} boxSize="icon" color="black" />}
-        bg="white"
+        bg="transparent"
         _groupHover={{ background: 'gray.450' }}
       />
       <Text fontSize="sm" fontWeight="800" textAlign="center" color="black">

--- a/src/components/common/UserList/index.tsx
+++ b/src/components/common/UserList/index.tsx
@@ -44,6 +44,7 @@ const UserList = ({
         aria-label="userInfo"
         icon={<MdArrowForwardIos />}
         bg="transparent"
+        color="gray.700"
       />
     </Flex>
   );

--- a/src/components/common/UserList/index.tsx
+++ b/src/components/common/UserList/index.tsx
@@ -1,10 +1,11 @@
-import { DEFAULT_WIDTH } from '@/constants/style';
+import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
 import {
   Avatar,
   Box,
   Flex,
   FlexProps,
   IconButton,
+  SystemProps,
   Text,
 } from '@chakra-ui/react';
 import { MdArrowForwardIos } from 'react-icons/md';
@@ -12,23 +13,37 @@ import { MdArrowForwardIos } from 'react-icons/md';
 interface UserListProps extends FlexProps {
   username: string;
   userImage?: string;
+  userImageSize?: SystemProps['boxSize'];
   content?: string;
 }
 
 const UserList = ({
-  username = '올챙이',
+  username,
   userImage,
+  userImageSize = '40px',
   content,
   ...props
 }: UserListProps) => {
   return (
-    <Flex w={DEFAULT_WIDTH} h="40px" align="center" {...props}>
-      <Avatar src={userImage} />
-      <Box flex={1}>
+    <Flex
+      w={DEFAULT_WIDTH}
+      pl={DEFAULT_PAGE_PADDING}
+      pr={DEFAULT_PAGE_PADDING}
+      h="40px"
+      align="center"
+      color="black"
+      {...props}
+    >
+      <Avatar src={userImage} boxSize={userImageSize} />
+      <Box fontWeight="medium" pl="16px" fontSize="1.4rem" flex={1}>
         <Text>{username}</Text>
         <Text>{content && content}</Text>
       </Box>
-      <IconButton aria-label="userInfo" icon={MdArrowForwardIos} />
+      <IconButton
+        aria-label="userInfo"
+        icon={<MdArrowForwardIos />}
+        bg="transparent"
+      />
     </Flex>
   );
 };

--- a/src/components/common/UserList/index.tsx
+++ b/src/components/common/UserList/index.tsx
@@ -32,6 +32,7 @@ const UserList = ({
       h="40px"
       align="center"
       color="black"
+      cursor="pointer"
       {...props}
     >
       <Avatar src={userImage} boxSize={userImageSize} />

--- a/src/components/common/UserList/index.tsx
+++ b/src/components/common/UserList/index.tsx
@@ -1,0 +1,36 @@
+import { DEFAULT_WIDTH } from '@/constants/style';
+import {
+  Avatar,
+  Box,
+  Flex,
+  FlexProps,
+  IconButton,
+  Text,
+} from '@chakra-ui/react';
+import { MdArrowForwardIos } from 'react-icons/md';
+
+interface UserListProps extends FlexProps {
+  username: string;
+  userImage?: string;
+  content?: string;
+}
+
+const UserList = ({
+  username = '올챙이',
+  userImage,
+  content,
+  ...props
+}: UserListProps) => {
+  return (
+    <Flex w={DEFAULT_WIDTH} h="40px" align="center" {...props}>
+      <Avatar src={userImage} />
+      <Box flex={1}>
+        <Text>{username}</Text>
+        <Text>{content && content}</Text>
+      </Box>
+      <IconButton aria-label="userInfo" icon={MdArrowForwardIos} />
+    </Flex>
+  );
+};
+
+export default UserList;

--- a/src/components/common/UserList/index.tsx
+++ b/src/components/common/UserList/index.tsx
@@ -1,7 +1,6 @@
 import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
 import {
   Avatar,
-  Box,
   Flex,
   FlexProps,
   IconButton,
@@ -36,10 +35,17 @@ const UserList = ({
       {...props}
     >
       <Avatar src={userImage} boxSize={userImageSize} />
-      <Box fontWeight="medium" pl="16px" fontSize="1.4rem" flex={1}>
+      <Flex
+        fontWeight="medium"
+        pl="16px"
+        fontSize="1.4rem"
+        flex={1}
+        justify="space-between"
+        pr="16px"
+      >
         <Text>{username}</Text>
         <Text>{content && content}</Text>
-      </Box>
+      </Flex>
       <IconButton
         aria-label="userInfo"
         icon={<MdArrowForwardIos />}

--- a/src/stories/components/Footer.stories.ts
+++ b/src/stories/components/Footer.stories.ts
@@ -5,10 +5,10 @@ const meta: Meta<typeof Footer> = {
   component: Footer,
   argTypes: {
     width: {
-      control: 'number',
+      control: 'text',
     },
     height: {
-      control: 'number',
+      control: 'text',
     },
   },
 };
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof Footer>;
 
 export const Deafult: Story = {
   args: {
-    width: 428,
-    height: 80,
+    width: '428px',
+    height: '80px',
   },
 };

--- a/src/stories/components/MainHeader.stories.ts
+++ b/src/stories/components/MainHeader.stories.ts
@@ -5,10 +5,10 @@ const meta: Meta<typeof MainHeader> = {
   component: MainHeader,
   argTypes: {
     width: {
-      control: 'number',
+      control: 'text',
     },
     height: {
-      control: 'number',
+      control: 'text',
     },
   },
 };
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof MainHeader>;
 
 export const Deafult: Story = {
   args: {
-    width: 428,
-    height: 80,
+    width: '428px',
+    height: '80px',
   },
 };

--- a/src/stories/components/UserList.stories.ts
+++ b/src/stories/components/UserList.stories.ts
@@ -1,0 +1,34 @@
+import UserList from '@/components/common/UserList';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof UserList> = {
+  component: UserList,
+  argTypes: {
+    width: {
+      control: 'text',
+    },
+    height: {
+      control: 'text',
+    },
+    username: {
+      control: 'text',
+    },
+    userImageSize: {
+      control: 'text',
+    },
+    content: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UserList>;
+
+export const Deafult: Story = {
+  args: {
+    width: '428px',
+    height: '40px',
+    username: '올챙이',
+  },
+};


### PR DESCRIPTION
## 작업 사항
- 검색 페이지와 잔디랭킹에서 사용할 UserList컴포넌트를 만들었습니다
- TextIconButton 컴포넌트의 배경색상을 하양=>투명으로 수정하였습니다
- MainHeader컴포넌트도 여타 Flex를 컨테이너로 사용하는 컴포넌트들처럼 타입을 FlexProps로 변경하였습니다
 
## 관련 이슈

#7 5번째 태스크입니다

## PR Point

- [ ] 간단한 UserList컴포넌트입니다. content(랭킹페이지의 시간)이 존재할 시 추가로 렌더링됩니다
- [ ] 랭킹페이지의 등수 + 이름을 username으로 던지면 될 것 같긴한데, prefix같은걸 추가해서 prefix + username 이런식으로 렌더링 할까용?
- [ ] `SystemProps['boxSize']`처럼 chakra-ui에서 사용하는 프롭스의 타입을 가져올수도 있네요!
- [ ] 수정사항이 발생했을때 pr을 더 잘게 쪼개는게 나을까요? 아주 간단한 수정이어서 쪼개진 않았습니다.

## 참고사항

content글자와 아이콘의 간격을 닉네임과 이미지의 간격과 동일하게 수정하였습니다
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/4a87e08c-4ca0-4a40-a986-ceacd3d53553)

