### PR TITLE
[Wip] 공통 컴포넌트 제작(6) PostListItem, TextIconButton(수정)

### DIFF
--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -1,10 +1,11 @@
 import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
-import { Flex, Text, VStack } from '@chakra-ui/react';
+import { Flex, FlexProps, HStack, Text, VStack } from '@chakra-ui/react';
 import TextIconButton from '../TextIconButton';
-import { MdFavorite } from 'react-icons/md';
+import { MdArticle, MdFavoriteBorder } from 'react-icons/md';
 
-interface PostListItemProps {
+interface PostListItemProps extends FlexProps {
   title: string;
+  body?: string;
   username: string;
   timeAgo: string;
   likeCount: number;
@@ -13,10 +14,12 @@ interface PostListItemProps {
 
 const PostListItem = ({
   title,
+  body,
   username,
   timeAgo,
   likeCount,
   commentCount,
+  ...props
 }: PostListItemProps) => {
   return (
     <Flex
@@ -24,27 +27,64 @@ const PostListItem = ({
       h="67px"
       pl={DEFAULT_PAGE_PADDING}
       pr={DEFAULT_PAGE_PADDING}
-      border="1px solid black"
       align="center"
       justify="space-between"
+      cursor="pointer"
+      {...props}
     >
       <VStack spacing="0" align="left">
-        <Text color="black" fontSize="1.4rem" fontWeight="semibold">
+        <Text
+          color="black"
+          fontSize="1.4rem"
+          fontWeight="semibold"
+          textOverflow="ellipsis"
+          overflow="hidden"
+          w="200px"
+          whiteSpace="nowrap"
+        >
           {title}
         </Text>
-        <Text color="gray.800" fontSize="1.2rem" fontWeight="medium">
-          {username}
+        <Text
+          color="gray.800"
+          fontSize="1.2rem"
+          fontWeight="medium"
+          textOverflow="ellipsis"
+          overflow="hidden"
+          w="200px"
+          whiteSpace="nowrap"
+        >
+          {body}
         </Text>
-        <Text color="gray.600" fontSize="1.2rem">
-          {timeAgo}
-        </Text>
+        <HStack>
+          <Text color="gray.800" fontSize="1.2rem" fontWeight="medium">
+            {username}
+          </Text>
+          <Text color="gray.600" fontSize="1.2rem">
+            {timeAgo}
+          </Text>
+        </HStack>
       </VStack>
       <VStack spacing="0">
         <TextIconButton
-          TheIcon={MdFavorite}
+          TheIcon={MdFavoriteBorder}
           textContent={likeCount.toString()}
+          boxSize="18px"
+          iconColor="pink.400"
+          fontSize="1.2rem"
+          fontWeight="normal"
+          textColor="gray.800"
+          textLocation="right"
         />
-        {commentCount}
+        <TextIconButton
+          TheIcon={MdArticle}
+          textContent={commentCount.toString()}
+          boxSize="18px"
+          iconColor="gray.800"
+          fontSize="1.2rem"
+          fontWeight="normal"
+          textColor="gray.800"
+          textLocation="right"
+        />
       </VStack>
     </Flex>
   );

--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -1,7 +1,30 @@
-import { Container } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 
-const PostListItem = () => {
-  return <Container>하이</Container>;
+interface PostListItemProps {
+  title: string;
+  username: string;
+  timeAgo: string;
+  likeCount: number;
+  commentCount: number;
+}
+
+const PostListItem = ({
+  title,
+  username,
+  timeAgo,
+  likeCount,
+  commentCount,
+}: PostListItemProps) => {
+  return (
+    <Flex>
+      <Box>
+        {title} {username} {timeAgo}
+      </Box>
+      <Box>
+        {likeCount} {commentCount}
+      </Box>
+    </Flex>
+  );
 };
 
 export default PostListItem;

--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@chakra-ui/react';
 
 const PostListItem = () => {
-  <Container>하이</Container>;
+  return <Container>하이</Container>;
 };
 
 export default PostListItem;

--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -1,4 +1,7 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
+import { Flex, Text, VStack } from '@chakra-ui/react';
+import TextIconButton from '../TextIconButton';
+import { MdFavorite } from 'react-icons/md';
 
 interface PostListItemProps {
   title: string;
@@ -16,13 +19,33 @@ const PostListItem = ({
   commentCount,
 }: PostListItemProps) => {
   return (
-    <Flex>
-      <Box>
-        {title} {username} {timeAgo}
-      </Box>
-      <Box>
-        {likeCount} {commentCount}
-      </Box>
+    <Flex
+      w={DEFAULT_WIDTH}
+      h="67px"
+      pl={DEFAULT_PAGE_PADDING}
+      pr={DEFAULT_PAGE_PADDING}
+      border="1px solid black"
+      align="center"
+      justify="space-between"
+    >
+      <VStack spacing="0" align="left">
+        <Text color="black" fontSize="1.4rem" fontWeight="semibold">
+          {title}
+        </Text>
+        <Text color="gray.800" fontSize="1.2rem" fontWeight="medium">
+          {username}
+        </Text>
+        <Text color="gray.600" fontSize="1.2rem">
+          {timeAgo}
+        </Text>
+      </VStack>
+      <VStack spacing="0">
+        <TextIconButton
+          TheIcon={MdFavorite}
+          textContent={likeCount.toString()}
+        />
+        {commentCount}
+      </VStack>
     </Flex>
   );
 };

--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -1,0 +1,7 @@
+import { Container } from '@chakra-ui/react';
+
+const PostListItem = () => {
+  <Container>하이</Container>;
+};
+
+export default PostListItem;

--- a/src/components/common/PostListItem/index.tsx
+++ b/src/components/common/PostListItem/index.tsx
@@ -17,8 +17,8 @@ const PostListItem = ({
   body,
   username,
   timeAgo,
-  likeCount,
-  commentCount,
+  likeCount = 0,
+  commentCount = 0,
   ...props
 }: PostListItemProps) => {
   return (

--- a/src/components/common/TextIconButton/index.tsx
+++ b/src/components/common/TextIconButton/index.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   IconButton,
   IconProps,
+  SystemProps,
   Text,
 } from '@chakra-ui/react';
 import { IconType } from 'react-icons';
@@ -13,6 +14,7 @@ interface TextIconButtonProps extends FlexProps {
   textContent: string;
   boxSize?: IconProps['boxSize'];
   textLocation?: 'left' | 'right' | 'top' | 'bottom';
+  fontSize?: SystemProps['fontSize'];
 }
 
 const TextIconButton = ({
@@ -20,6 +22,7 @@ const TextIconButton = ({
   textContent,
   boxSize = 'icon',
   textLocation = 'bottom',
+  fontSize = 'sm',
   ...props
 }: TextIconButtonProps) => {
   const calculateFlexDir = (
@@ -53,7 +56,12 @@ const TextIconButton = ({
         bg="transparent"
         _groupHover={{ background: 'gray.450' }}
       />
-      <Text fontSize="sm" fontWeight="800" textAlign="center" color="black">
+      <Text
+        fontSize={fontSize}
+        fontWeight="800"
+        textAlign="center"
+        color="black"
+      >
         {textContent}
       </Text>
     </Flex>

--- a/src/components/common/TextIconButton/index.tsx
+++ b/src/components/common/TextIconButton/index.tsx
@@ -22,7 +22,9 @@ const TextIconButton = ({
   textLocation = 'bottom',
   ...props
 }: TextIconButtonProps) => {
-  const flexDir = (textLocation: TextIconButtonProps['textLocation']) => {
+  const calculateFlexDir = (
+    textLocation: TextIconButtonProps['textLocation'],
+  ) => {
     switch (textLocation) {
       case 'bottom':
         return 'column';
@@ -38,7 +40,7 @@ const TextIconButton = ({
   };
   return (
     <Flex
-      flexDir={flexDir(textLocation)}
+      flexDir={calculateFlexDir(textLocation)}
       align="center"
       justify="center"
       cursor="pointer"

--- a/src/components/common/TextIconButton/index.tsx
+++ b/src/components/common/TextIconButton/index.tsx
@@ -4,8 +4,8 @@ import {
   Icon,
   IconButton,
   IconProps,
-  SystemProps,
   Text,
+  TextProps,
 } from '@chakra-ui/react';
 import { IconType } from 'react-icons';
 
@@ -14,15 +14,21 @@ interface TextIconButtonProps extends FlexProps {
   textContent: string;
   boxSize?: IconProps['boxSize'];
   textLocation?: 'left' | 'right' | 'top' | 'bottom';
-  fontSize?: SystemProps['fontSize'];
+  fontSize?: TextProps['fontSize'];
+  iconColor?: IconProps['color'];
+  textColor?: TextProps['color'];
+  fontWeight?: TextProps['fontWeight'];
 }
 
 const TextIconButton = ({
   TheIcon,
   textContent,
-  boxSize = 'icon',
   textLocation = 'bottom',
   fontSize = 'sm',
+  textColor = 'black',
+  fontWeight = '800',
+  boxSize = 'icon',
+  iconColor = 'black',
   ...props
 }: TextIconButtonProps) => {
   const calculateFlexDir = (
@@ -52,15 +58,15 @@ const TextIconButton = ({
     >
       <IconButton
         aria-label="home"
-        icon={<Icon as={TheIcon} boxSize={boxSize} color="black" />}
+        icon={<Icon as={TheIcon} boxSize={boxSize} color={iconColor} />}
         bg="transparent"
         _groupHover={{ background: 'gray.450' }}
       />
       <Text
         fontSize={fontSize}
-        fontWeight="800"
+        fontWeight={fontWeight}
         textAlign="center"
-        color="black"
+        color={textColor}
       >
         {textContent}
       </Text>

--- a/src/components/common/TextIconButton/index.tsx
+++ b/src/components/common/TextIconButton/index.tsx
@@ -1,17 +1,53 @@
-import { Flex, Icon, IconButton, Text } from '@chakra-ui/react';
+import {
+  Flex,
+  FlexProps,
+  Icon,
+  IconButton,
+  IconProps,
+  Text,
+} from '@chakra-ui/react';
 import { IconType } from 'react-icons';
 
-interface TextIconButtonProps {
+interface TextIconButtonProps extends FlexProps {
   TheIcon: IconType;
   textContent: string;
+  boxSize?: IconProps['boxSize'];
+  textLocation?: 'left' | 'right' | 'top' | 'bottom';
 }
 
-const TextIconButton = ({ TheIcon, textContent }: TextIconButtonProps) => {
+const TextIconButton = ({
+  TheIcon,
+  textContent,
+  boxSize = 'icon',
+  textLocation = 'bottom',
+  ...props
+}: TextIconButtonProps) => {
+  const flexDir = (textLocation: TextIconButtonProps['textLocation']) => {
+    switch (textLocation) {
+      case 'bottom':
+        return 'column';
+      case 'top':
+        return 'column-reverse';
+      case 'left':
+        return 'row-reverse';
+      case 'right':
+        return 'row';
+      default:
+        return 'column';
+    }
+  };
   return (
-    <Flex flexDir="column" align="center" cursor="pointer" role="group">
+    <Flex
+      flexDir={flexDir(textLocation)}
+      align="center"
+      justify="center"
+      cursor="pointer"
+      role="group"
+      {...props}
+    >
       <IconButton
         aria-label="home"
-        icon={<Icon as={TheIcon} boxSize="icon" color="black" />}
+        icon={<Icon as={TheIcon} boxSize={boxSize} color="black" />}
         bg="transparent"
         _groupHover={{ background: 'gray.450' }}
       />

--- a/src/components/common/UserListItem/index.tsx
+++ b/src/components/common/UserListItem/index.tsx
@@ -9,20 +9,20 @@ import {
 } from '@chakra-ui/react';
 import { MdArrowForwardIos } from 'react-icons/md';
 
-interface UserListProps extends FlexProps {
+interface UserListItemProps extends FlexProps {
   username: string;
   userImage?: string;
   userImageSize?: SystemProps['boxSize'];
   content?: string;
 }
 
-const UserList = ({
+const UserListItem = ({
   username,
   userImage,
   userImageSize = '40px',
   content,
   ...props
-}: UserListProps) => {
+}: UserListItemProps) => {
   return (
     <Flex
       w={DEFAULT_WIDTH}
@@ -56,4 +56,4 @@ const UserList = ({
   );
 };
 
-export default UserList;
+export default UserListItem;

--- a/src/stories/components/PostListItem.stories.ts
+++ b/src/stories/components/PostListItem.stories.ts
@@ -7,6 +7,9 @@ const meta: Meta<typeof PostListItem> = {
     title: {
       control: 'text',
     },
+    body: {
+      control: 'text',
+    },
     username: {
       control: 'text',
     },
@@ -27,7 +30,8 @@ type Story = StoryObj<typeof PostListItem>;
 
 export const Deafult: Story = {
   args: {
-    title: '제목입니다',
+    title: '제목입니다제목입니다제목입니다제목입니다제목입니다',
+    body: '내용이에요내용이에요내용이에요내용이에요내용이에요내용이에',
     username: '올챙이',
     timeAgo: '2일전',
     likeCount: 10,

--- a/src/stories/components/PostListItem.stories.ts
+++ b/src/stories/components/PostListItem.stories.ts
@@ -3,12 +3,34 @@ import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof PostListItem> = {
   component: PostListItem,
-  argTypes: {},
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    username: {
+      control: 'text',
+    },
+    timeAgo: {
+      control: 'text',
+    },
+    likeCount: {
+      control: 'number',
+    },
+    commentCount: {
+      control: 'number',
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof PostListItem>;
 
 export const Deafult: Story = {
-  args: {},
+  args: {
+    title: '제목입니다',
+    username: '올챙이',
+    timeAgo: '2일전',
+    likeCount: 10,
+    commentCount: 20,
+  },
 };

--- a/src/stories/components/PostListItem.stories.ts
+++ b/src/stories/components/PostListItem.stories.ts
@@ -1,0 +1,14 @@
+import PostListItem from '@/components/common/PostListItem';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PostListItem> = {
+  component: PostListItem,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof PostListItem>;
+
+export const Deafult: Story = {
+  args: {},
+};

--- a/src/stories/components/TextIconButton.stories.ts
+++ b/src/stories/components/TextIconButton.stories.ts
@@ -18,6 +18,15 @@ const meta: Meta<typeof TextIconButton> = {
     fontSize: {
       control: 'text',
     },
+    fontWeight: {
+      control: 'text',
+    },
+    textColor: {
+      control: 'text',
+    },
+    iconColor: {
+      control: 'text',
+    },
   },
 };
 

--- a/src/stories/components/TextIconButton.stories.ts
+++ b/src/stories/components/TextIconButton.stories.ts
@@ -15,6 +15,9 @@ const meta: Meta<typeof TextIconButton> = {
       options: ['top', 'bottom', 'left', 'right'],
       control: 'select',
     },
+    fontSize: {
+      control: 'text',
+    },
   },
 };
 

--- a/src/stories/components/TextIconButton.stories.ts
+++ b/src/stories/components/TextIconButton.stories.ts
@@ -8,6 +8,13 @@ const meta: Meta<typeof TextIconButton> = {
     textContent: {
       control: 'text',
     },
+    boxSize: {
+      control: 'text',
+    },
+    textLocation: {
+      options: ['top', 'bottom', 'left', 'right'],
+      control: 'select',
+    },
   },
 };
 

--- a/src/stories/components/UserListItem.stories.ts
+++ b/src/stories/components/UserListItem.stories.ts
@@ -1,8 +1,8 @@
-import UserList from '@/components/common/UserList';
+import UserListItem from '@/components/common/UserListItem';
 import { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof UserList> = {
-  component: UserList,
+const meta: Meta<typeof UserListItem> = {
+  component: UserListItem,
   argTypes: {
     width: {
       control: 'text',
@@ -23,7 +23,7 @@ const meta: Meta<typeof UserList> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof UserList>;
+type Story = StoryObj<typeof UserListItem>;
 
 export const Deafult: Story = {
   args: {


### PR DESCRIPTION
## 작업 사항

- 글 목록에서 사용할 PostListItem 컴포넌트를 제작하였습니다(스토리북 포함)
- TextIconButton의 text방향 지정 및 텍스트 스타일 지정 등 유연성을 더 늘렸습니다.

## 관련 이슈

#7 6번째 태스크입니다

## PR Point

- [x] props네이밍이 적절한가요?
- [ ] 말줄임표를 위해 일단 제목과 내용너비를 200px로 설정해두었습니다. calc를 사용하려했는데 잘 안먹히네요..ㅠㅠ
- [ ] 여러 chakra-ui로 이루어진 컴포넌트의 props를 전달할때 혹시 이런 방법은 어떨까요?
```jsx
const Component = ({flexStyle, textStyle, iconStyle, etcProps}) => {
  <Flex {...flexStyle}>
   <Text {...textStyle}>
   <Icon {...IconStyle}>
   ...
}
```
컴포넌트 props의 덩치가 너무 커지는건 아닌가 고민됩니다ㅎㅎ
- [ ] 이번에는 PostListItem이라고 명명해보았습니다. 제가 PostList컴포넌트까지 아예 react-query를 이용해서 만드는것도 하나의 방법일 것 같은데요, 어떻게 생각하시는지 궁금합니다. 또한 그렇게된다면 이전에 작성했던 UserList컴포넌트를 UserListItem 컴포넌트로 바꾼 뒤, UserList컴포넌트를 제작해 react-query를 넣어보겠습니다

## 참고사항
 재사용 가능하게 만든다는 것이 참으로 어려운 것 같습니다! 이번에 TextIconButton도 꽤 수정사항이 생겨서 같이 봐주시면 감사하겠습니다.

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/84f7a328-7782-4bfd-8bc5-2cba21f7f182)
