### PR TITLE
[Fix] axios interceptors 옵션 수정

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -10,19 +10,14 @@ export const axiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
-
+//TODO : 추후에 merge된 이후 상수로 바꾸기
 axiosInstance.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('login-token');
   if (token && config.headers) {
     config.headers.Authorization = `bearer ${token}`;
   }
   return config;
 });
-
-axiosInstance.interceptors.response.use(
-  (res) => res,
-  (err) => Promise.reject(err),
-);
 
 export const getRequest = async <T>(
   url: string,


### PR DESCRIPTION
## 작업 사항
- interceptors.response 설정 삭제 및 localStorage

## 관련 이슈

## PR Point
- interceptors에서 대신 오류처리를 해주지 않고 바로 에러를 반환하도록 설정
- #19 해당 PR에서 localStorage 및 로그인 시 토큰 저장 기능이 있어서, 이 PR이 merge된 이후에 정상적으로 토큰 사용이 가능할 것 같습니다.
<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->
