### PR TITLE
[Hotfix] 404Page, BoardEnterPage Error 수정

### DIFF
--- a/src/pages/404Page/index.tsx
+++ b/src/pages/404Page/index.tsx
@@ -10,7 +10,7 @@ const ErrorPage = () => {
     <>
       <MainHeader />
       <Box w={DEFAULT_WIDTH} h="100vh">
-        <Image src="src/assets/404.svg" alt="404 Error" />
+        <Image src="/src/assets/404.svg" alt="404 Error" />
         <Button
           w="388px"
           h="50px"

--- a/src/pages/BoardEnterPage/index.tsx
+++ b/src/pages/BoardEnterPage/index.tsx
@@ -12,7 +12,7 @@ const BoardEnterPage = () => {
   return (
     <>
       <PageHeader pageName="게시판" />
-      {params ? (
+      {params.boardName ? (
         <Outlet />
       ) : (
         <Box w={DEFAULT_WIDTH} h="100vh" p={`0 ${DEFAULT_PAGE_PADDING}`}>


### PR DESCRIPTION
## 작업 사항

- 404Page에서 `/boardd/free` 처럼 중첩 라우터일 때 404 이미지가 깨지는 버그 수정
- BoardEnterPage에서 `/board` 일 때 아무것도 출력되지 않는 버그 수정

## 관련 이슈

#44 #61 

## PR Point

버그를 수정한 것이라 코드 변경 내용은 많지 않습니다 !

## 참고사항

봐주실 코드의 양은 많지 않습니다 :)
