### PR TITLE
[Fix] PageHeader컴포넌트 아이콘 클릭시 페이지 이동되게 변경 및 스토리북 수정(간단)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,7 +3,6 @@ import {theme} from "../src/theme"
 
 
 const preview: Preview = {
-
   parameters: {
     chakra:{
       theme,

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -10,11 +10,17 @@ import { Flex, Text } from '@chakra-ui/layout';
 import { FlexProps } from '@chakra-ui/react';
 import { MdArrowBackIos } from 'react-icons/md';
 import Badge from '../common/Badge';
+import { useNavigate } from 'react-router-dom';
 
 interface PageHeaderProps extends FlexProps {
   pageName: string;
 }
+
 const PageHeader = ({ pageName, ...props }: PageHeaderProps) => {
+  const navigate = useNavigate();
+
+  const goBack = () => navigate(-1);
+
   return (
     <Flex
       w={DEFAULT_WIDTH}
@@ -26,8 +32,7 @@ const PageHeader = ({ pageName, ...props }: PageHeaderProps) => {
       color="black"
       {...props}
     >
-      {/* 여기에 뒤로가기 기능 달아주면 됩니다 */}
-      <Flex w="69px" align="center" cursor="pointer">
+      <Flex w="69px" align="center" cursor="pointer" onClick={goBack}>
         <Icon as={MdArrowBackIos} boxSize="icon" />
         <Text fontSize="sm">뒤로가기</Text>
       </Flex>
@@ -40,7 +45,8 @@ const PageHeader = ({ pageName, ...props }: PageHeaderProps) => {
         <IconButton
           aria-label="search"
           icon={<SearchIcon color="black" boxSize="icon" />}
-          bgColor="white"
+          bg="transparent"
+          onClick={() => navigate('/search')}
         />
         <IconButton
           aria-label="notify"
@@ -49,7 +55,8 @@ const PageHeader = ({ pageName, ...props }: PageHeaderProps) => {
               <BellIcon color="black" boxSize="icon" />
             </Badge>
           }
-          bgColor="white"
+          bg="transparent"
+          onClick={() => navigate('/notification')}
         />
       </Flex>
     </Flex>

--- a/src/stories/components/PageHeader.stories.ts
+++ b/src/stories/components/PageHeader.stories.ts
@@ -1,8 +1,10 @@
 import PageHeader from '@/components/PageHeader';
 import { Meta, StoryObj } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 const meta: Meta<typeof PageHeader> = {
   component: PageHeader,
+  decorators: [withRouter],
   argTypes: {
     width: {
       control: 'text',


### PR DESCRIPTION
## 작업 사항

페이지 헤더 뒤로가기 클릭시 뒤로가기 및 아이콘 누를시 라우팅 처리 완료하였습니다

## 관련 이슈

#71 입니다

## PR Point

짧아서 거의 볼게 없습니다!

## 참고사항
