### PR TITLE
[Fix] 푸터 아이콘 하이라이트 및 라우팅 (살짝간단?)

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -8,31 +8,63 @@ import {
   MdPersonOutline,
 } from 'react-icons/md';
 import TextIconButton from '../common/TextIconButton';
-
-const elementsData = [
-  {
-    icon: MdHome,
-    text: '홈',
-  },
-  {
-    icon: MdEmojiEvents,
-    text: '랭킹',
-  },
-  {
-    icon: MdOutlineTimer,
-    text: '타이머',
-  },
-  {
-    icon: MdOutlineMessage,
-    text: '게시판',
-  },
-  {
-    icon: MdPersonOutline,
-    text: '내정보',
-  },
-];
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 const Footer = ({ ...props }: FlexProps) => {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [currentPageName, setCurrentPageName] = useState('');
+
+  const elementsData = [
+    {
+      icon: MdHome,
+      text: '홈',
+    },
+    {
+      icon: MdEmojiEvents,
+      text: '랭킹',
+    },
+    {
+      icon: MdOutlineTimer,
+      text: '타이머',
+    },
+    {
+      icon: MdOutlineMessage,
+      text: '게시판',
+    },
+    {
+      icon: MdPersonOutline,
+      text: '내정보',
+    },
+  ];
+
+  const footerIconPath = new Map([
+    ['', '홈'],
+    ['rank', '랭킹'],
+    ['timer', '타이머'],
+    ['board', '게시판'],
+    ['mypage', '내정보'],
+  ]);
+
+  footerIconPath.forEach((value, key, map) => {
+    map.set(value, key);
+  });
+
+  useEffect(() => {
+    setCurrentPageName(pathname?.split('/')?.[1]);
+  }, [pathname]);
+
+  const matchedPageNameStyle = (currentPageName: string, iconText: string) => {
+    if (footerIconPath.get(currentPageName) === iconText) {
+      return {
+        iconColor: 'pink.300',
+        color: 'pink.300',
+      };
+    }
+    return {};
+  };
+
   return (
     <Flex
       pl="31px"
@@ -47,7 +79,13 @@ const Footer = ({ ...props }: FlexProps) => {
       {...props}
     >
       {elementsData.map(({ icon, text }) => (
-        <TextIconButton key={text} TheIcon={icon} textContent={text} />
+        <TextIconButton
+          key={text}
+          TheIcon={icon}
+          textContent={text}
+          onClick={() => navigate(`/${footerIconPath.get(text)}`)}
+          {...matchedPageNameStyle(currentPageName, text)}
+        />
       ))}
     </Flex>
   );

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -10,7 +10,7 @@ import {
 import TextIconButton from '../common/TextIconButton';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useMemo, useState } from 'react';
-const interactiveMap = <K, V>(map: Map<K, V>): Map<K | V, V | K> => {
+const getInteractiveMap = <K, V>(map: Map<K, V>): Map<K | V, V | K> => {
   const newMap = new Map<K | V, V | K>();
   map.forEach((value, key) => {
     newMap.set(value, key);
@@ -49,7 +49,7 @@ const Footer = ({ ...props }: FlexProps) => {
 
   const footerIconPath = useMemo<Map<string, string>>(
     () =>
-      interactiveMap<string, string>(
+      getInteractiveMap<string, string>(
         new Map([
           ['', '홈'],
           ['rank', '랭킹'],

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -9,6 +9,29 @@ import {
 } from 'react-icons/md';
 import TextIconButton from '../common/TextIconButton';
 
+const elementsData = [
+  {
+    icon: MdHome,
+    text: '홈',
+  },
+  {
+    icon: MdEmojiEvents,
+    text: '랭킹',
+  },
+  {
+    icon: MdOutlineTimer,
+    text: '타이머',
+  },
+  {
+    icon: MdOutlineMessage,
+    text: '게시판',
+  },
+  {
+    icon: MdPersonOutline,
+    text: '내정보',
+  },
+];
+
 const Footer = ({ ...props }: FlexProps) => {
   return (
     <Flex
@@ -23,12 +46,9 @@ const Footer = ({ ...props }: FlexProps) => {
       h={DEFAULT_HEADER_HEIGHT}
       {...props}
     >
-      {/* [{icon:MdHome, textContent:"홈"}, ...]  이렇게 받아와서 map을 돌려도 좋아보입니다*/}
-      <TextIconButton TheIcon={MdHome} textContent="홈" />
-      <TextIconButton TheIcon={MdEmojiEvents} textContent="랭킹" />
-      <TextIconButton TheIcon={MdOutlineTimer} textContent="타이머" />
-      <TextIconButton TheIcon={MdOutlineMessage} textContent="게시판" />
-      <TextIconButton TheIcon={MdPersonOutline} textContent="내정보" />
+      {elementsData.map(({ icon, text }) => (
+        <TextIconButton key={text} TheIcon={icon} textContent={text} />
+      ))}
     </Flex>
   );
 };

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -10,14 +10,7 @@ import {
 import TextIconButton from '../common/TextIconButton';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useMemo, useState } from 'react';
-const getInteractiveMap = <K, V>(map: Map<K, V>): Map<K | V, V | K> => {
-  const newMap = new Map<K | V, V | K>();
-  map.forEach((value, key) => {
-    newMap.set(value, key);
-    newMap.set(key, value);
-  });
-  return newMap;
-};
+import { getInteractiveMap } from '@/utils/getInteractiveMap';
 
 const Footer = ({ ...props }: FlexProps) => {
   const { pathname } = useLocation();

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -9,7 +9,15 @@ import {
 } from 'react-icons/md';
 import TextIconButton from '../common/TextIconButton';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+const interactiveMap = <K, V>(map: Map<K, V>): Map<K | V, V | K> => {
+  const newMap = new Map<K | V, V | K>();
+  map.forEach((value, key) => {
+    newMap.set(value, key);
+    newMap.set(key, value);
+  });
+  return newMap;
+};
 
 const Footer = ({ ...props }: FlexProps) => {
   const { pathname } = useLocation();
@@ -39,17 +47,19 @@ const Footer = ({ ...props }: FlexProps) => {
     },
   ];
 
-  const footerIconPath = new Map([
-    ['', '홈'],
-    ['rank', '랭킹'],
-    ['timer', '타이머'],
-    ['board', '게시판'],
-    ['mypage', '내정보'],
-  ]);
-
-  footerIconPath.forEach((value, key, map) => {
-    map.set(value, key);
-  });
+  const footerIconPath = useMemo<Map<string, string>>(
+    () =>
+      interactiveMap<string, string>(
+        new Map([
+          ['', '홈'],
+          ['rank', '랭킹'],
+          ['timer', '타이머'],
+          ['board', '게시판'],
+          ['mypage', '내정보'],
+        ]),
+      ),
+    [],
+  );
 
   useEffect(() => {
     setCurrentPageName(pathname?.split('/')?.[1]);

--- a/src/stories/components/Footer.stories.ts
+++ b/src/stories/components/Footer.stories.ts
@@ -1,8 +1,10 @@
 import Footer from '@/components/Footer';
 import { Meta, StoryObj } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 const meta: Meta<typeof Footer> = {
   component: Footer,
+  decorators: [withRouter],
   argTypes: {
     width: {
       control: 'text',

--- a/src/test/getInteractiveMap.test.ts
+++ b/src/test/getInteractiveMap.test.ts
@@ -1,0 +1,23 @@
+import { getInteractiveMap } from '@/utils/getInteractiveMap';
+import { expect, test } from 'vitest';
+
+test('oneside map convert to new interactiveMap"', () => {
+  expect(
+    getInteractiveMap(
+      new Map([
+        ['1', 'one'],
+        ['2', 'two'],
+        ['3', 'three'],
+      ]),
+    ),
+  ).toEqual(
+    new Map([
+      ['1', 'one'],
+      ['2', 'two'],
+      ['3', 'three'],
+      ['one', '1'],
+      ['two', '2'],
+      ['three', '3'],
+    ]),
+  );
+});

--- a/src/utils/getInteractiveMap.ts
+++ b/src/utils/getInteractiveMap.ts
@@ -1,0 +1,8 @@
+export const getInteractiveMap = <K, V>(map: Map<K, V>): Map<K | V, V | K> => {
+  const newMap = new Map<K | V, V | K>();
+  map.forEach((value, key) => {
+    newMap.set(value, key);
+    newMap.set(key, value);
+  });
+  return newMap;
+};


### PR DESCRIPTION
## 작업 사항

- 푸터 아이콘 path기반 하이라이트 및 클릭시 라우팅 이동
- 푸터 스토리북 수정

## 관련 이슈

#73 입니다

## PR Point

- 배열을 만들어 TextIconButton을 map메서드로 뿌려주었습니다
- Map자료구조를 쌍방향으로 설정하여 영문=>한글, 한글=>영문에 대응하였습니다 

## 참고사항

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/d0b15534-b94f-429c-8677-9154678b4d09)

