### PR TITLE
[Feature] MainPage 게시판 더보기 버튼 클릭 시 '/board' 로 넘어가게 처리

### DIFF
--- a/src/pages/MainPage/BoardListPreview.tsx
+++ b/src/pages/MainPage/BoardListPreview.tsx
@@ -1,22 +1,25 @@
 import { DEFAULT_WIDTH } from '@/constants/style';
 import { ChevronRightIcon } from '@chakra-ui/icons';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+
+const DUMMY_GALLERY_DATA = [
+  {
+    name: '자유 게시판',
+    posts: ['자유게시판 첫 번째 글', '자유게시판 두 번째 글'],
+  },
+  {
+    name: '목표 달성 & 인증',
+    posts: ['목표 달성 & 인증 첫 번째 글', '목표 달성 & 인증 두 번째 글'],
+  },
+  {
+    name: '정보 공유 게시판',
+    posts: ['정보 공유 게시판 첫 번째 글', '정보 공유 게시판 두 번째 글'],
+  },
+];
 
 const BoardListPreview = () => {
-  const DUMMY_GALLERY_DATA = [
-    {
-      name: '자유 게시판',
-      posts: ['자유게시판 첫 번째 글', '자유게시판 두 번째 글'],
-    },
-    {
-      name: '목표 달성 & 인증',
-      posts: ['목표 달성 & 인증 첫 번째 글', '목표 달성 & 인증 두 번째 글'],
-    },
-    {
-      name: '정보 공유 게시판',
-      posts: ['정보 공유 게시판 첫 번째 글', '정보 공유 게시판 두 번째 글'],
-    },
-  ];
+  const navigate = useNavigate();
 
   return (
     <Flex maxW={DEFAULT_WIDTH} marginTop="30px" direction="column">
@@ -29,7 +32,12 @@ const BoardListPreview = () => {
         <Text color="black" fontSize="3xl" fontWeight="medium" cursor="default">
           게시판
         </Text>
-        <Button fontSize="md" color="gray.800" bg="white">
+        <Button
+          fontSize="md"
+          color="gray.800"
+          bg="white"
+          onClick={() => navigate('/board')}
+        >
           더 보기 <ChevronRightIcon />
         </Button>
       </Flex>


### PR DESCRIPTION
## 작업 사항

 - MainPage에서 게시판 더보기 버튼 클릭 시 '/board' 로 넘어가게 처리 했습니다

## 관련 이슈



## PR Point

나머지 처리해야 할 것은, DB 삭제 후 정식 데이터를 삽입한 후 작업이 가능할 것 같아 우선적으로 처리할 수 있는 부분을 완료했습니다.

## 참고사항

봐주실 코드의 양은 적습니다 !
