### PR TITLE
[Fix] BoardPage channel id 변경, 스타일링 수정

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,6 +18,7 @@ import { useChannelList } from '@/hooks/useChannelList';
 import NotificationPage from '@/pages/NotificationPage';
 import TimerPage from '@/pages/TimerPage';
 import '@fontsource/noto-sans-kr';
+import { Fragment } from 'react';
 
 const App = () => {
   const { channelListData } = useChannelList();
@@ -40,18 +41,13 @@ const App = () => {
           <Route path="*" element={<ErrorPage />} />
           <Route path="/board" element={<BoardEnterPage />} />
           {channelListData?.map((board) => (
-            <>
+            <Fragment key={board._id}>
+              <Route path={`/board/${board.name}`} element={<BoardPage />} />
               <Route
-                key={board._id}
-                path={`/board/${board.name}`}
-                element={<BoardPage />}
-              />
-              <Route
-                key={board._id}
                 path={`/board/${board.name}/post`}
                 element={<PostEditPage />}
               />
-            </>
+            </Fragment>
           ))}
           <Route path="/notification" element={<NotificationPage />} />
           <Route path="/timer" element={<TimerPage />} />

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -79,6 +79,7 @@ const Footer = ({ ...props }: FlexProps) => {
       bg="gray.50"
       w={DEFAULT_WIDTH}
       h={DEFAULT_HEADER_HEIGHT}
+      shrink="0"
       {...props}
     >
       {elementsData.map(({ icon, text }) => (

--- a/src/components/OnlineUserProfile/index.tsx
+++ b/src/components/OnlineUserProfile/index.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Circle, Flex, Text } from '@chakra-ui/react';
+import { Avatar, AvatarBadge, Flex, Text } from '@chakra-ui/react';
 
 interface OnlineUserProfileProps {
   username: string;
@@ -9,14 +9,11 @@ const OnlineUserProfile = ({ username, image }: OnlineUserProfileProps) => {
   return (
     <Flex w="60px" h="80px" flexDirection="column" alignItems="center">
       <Avatar src={image} w="60px" h="60px" mb="5px">
-        {/* <AvatarBadge boxSize="1.25em" bg="#37E97E" /> */}
+        <AvatarBadge boxSize="1.25em" bg="#37E97E" />
       </Avatar>
-      <Flex alignItems="center">
-        <Text color="black" fontSize="1.2rem" fontWeight="semibold">
-          {username}
-        </Text>
-        <Circle size="6px" bg="#37E97E" ml="5px" />
-      </Flex>
+      <Text color="black" fontSize="1.2rem" fontWeight="semibold">
+        {username}
+      </Text>
     </Flex>
   );
 };

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -25,6 +25,7 @@ const PageHeader = ({ pageName, ...props }: PageHeaderProps) => {
     <Flex
       w={DEFAULT_WIDTH}
       h={DEFAULT_HEADER_HEIGHT}
+      shrink="0"
       align="center"
       pl={DEFAULT_PAGE_PADDING}
       pr={DEFAULT_PAGE_PADDING}

--- a/src/hooks/useChannelList.ts
+++ b/src/hooks/useChannelList.ts
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 import { useQuery } from 'react-query';
 
 export const useChannelList = () => {
-  const { data, error } = useQuery<Channel[], AxiosError>(
+  const { data, isError } = useQuery<Channel[], AxiosError>(
     CHANNEL_LIST,
     getChannelList,
     {
@@ -24,5 +24,5 @@ export const useChannelList = () => {
 
   const channelListData = data;
 
-  return { channelListData, error };
+  return { channelListData, isError };
 };

--- a/src/hooks/useChannelList.ts
+++ b/src/hooks/useChannelList.ts
@@ -12,6 +12,13 @@ export const useChannelList = () => {
       meta: {
         errorMessage: '채널 목록을 가져올 때 에러가 발생했습니다.',
       },
+      select: (data) =>
+        data.filter(
+          (channel) =>
+            channel.description === '자유 게시판' ||
+            channel.description === '인증 & 회고 게시판' ||
+            channel.description === '정보 공유 게시판',
+        ),
     },
   );
 

--- a/src/pages/BoardPage/BoardPostList.tsx
+++ b/src/pages/BoardPage/BoardPostList.tsx
@@ -1,18 +1,22 @@
 import PostList from '@/components/PostList';
-import { TEST_CHANNEL_ID } from '@/constants/apiTest';
 import { DEFAULT_WIDTH } from '@/constants/style';
 import styled from '@emotion/styled';
 
-const BoardPostList = () => {
+interface BoardPostListProps {
+  channelId: string;
+}
+
+const BoardPostList = ({ channelId }: BoardPostListProps) => {
   return (
     <BoardPageBody>
-      <PostList keyword="" channelId={TEST_CHANNEL_ID} />
+      <PostList keyword="" channelId={channelId} />
     </BoardPageBody>
   );
 };
 
 const BoardPageBody = styled.div`
   width: ${DEFAULT_WIDTH};
+  flex-grow: 1;
   margin-bottom: 50px;
   padding: 10px 0;
   overflow-y: auto;

--- a/src/pages/BoardPage/OnlineUsers.tsx
+++ b/src/pages/BoardPage/OnlineUsers.tsx
@@ -22,7 +22,7 @@ const OnlineUsers = () => {
           접속 중인 사용자가 없습니다.
         </Text>
       ) : (
-        <Flex gap="8px">
+        <Flex gap="10px" overflowX="auto">
           {onlineUsersListData?.map((onlineUser) => (
             <OnlineUserProfile
               key={onlineUser._id}

--- a/src/pages/BoardPage/OnlineUsers.tsx
+++ b/src/pages/BoardPage/OnlineUsers.tsx
@@ -1,16 +1,39 @@
 import OnlineUserProfile from '@/components/OnlineUserProfile';
-import { Flex } from '@chakra-ui/react';
+import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
+import { useOnlineUserList } from '@/hooks/useOnlineUserList';
+import { Box, Divider, Flex, Text } from '@chakra-ui/react';
 
-interface OnlineUsersProps {
-  username: string;
-  image: string;
-}
+const OnlineUsers = () => {
+  const { onlineUsersListData } = useOnlineUserList();
 
-const OnlineUsers = ({ username = '테스트', image = '' }: OnlineUsersProps) => {
   return (
-    <Flex gap="8px">
-      <OnlineUserProfile username={username} image={image} />
-    </Flex>
+    <Box w={DEFAULT_WIDTH} padding={`10px ${DEFAULT_PAGE_PADDING}`}>
+      <Text
+        fontSize="1.6rem"
+        fontWeight="semibold"
+        color="black"
+        cursor="default"
+        mb="10px"
+      >
+        실시간 접속자
+      </Text>
+      {onlineUsersListData && !onlineUsersListData.length ? (
+        <Text fontSize="1.2rem" fontWeight="medium" cursor="default" mb="10px">
+          접속 중인 사용자가 없습니다.
+        </Text>
+      ) : (
+        <Flex gap="8px">
+          {onlineUsersListData?.map((onlineUser) => (
+            <OnlineUserProfile
+              key={onlineUser._id}
+              username={onlineUser.username}
+              image={onlineUser.image}
+            />
+          ))}
+        </Flex>
+      )}
+      <Divider mt="13px" color="gray.450" />
+    </Box>
   );
 };
 

--- a/src/pages/BoardPage/WriteButton.tsx
+++ b/src/pages/BoardPage/WriteButton.tsx
@@ -8,7 +8,7 @@ const WriteButton = () => {
   return (
     <Box
       position="fixed"
-      bottom="50px"
+      bottom="80px"
       left="50%"
       transform="translate(-50%, -50%)"
     >

--- a/src/pages/BoardPage/index.tsx
+++ b/src/pages/BoardPage/index.tsx
@@ -1,17 +1,12 @@
-import { Box, Divider, Text } from '@chakra-ui/react';
 import { useLocation } from 'react-router-dom';
 import Footer from '@/components/Footer';
 import PageHeader from '@/components/PageHeader';
-import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
-// import { BOARD_LIST } from '@/constants/Board';
 import OnlineUsers from '@/pages/BoardPage/OnlineUsers';
 import WriteButton from '@/pages/BoardPage/WriteButton';
 import BoardPostList from '@/pages/BoardPage/BoardPostList';
-import { useOnlineUserList } from '@/hooks/useOnlineUserList';
 import { useChannelList } from '@/hooks/useChannelList';
 
 const BoardPage = () => {
-  const { onlineUsersListData } = useOnlineUserList();
   const { channelListData } = useChannelList();
   const location = useLocation();
   const pathInfo = channelListData?.filter(
@@ -21,41 +16,10 @@ const BoardPage = () => {
   return (
     <>
       <PageHeader pageName={(pathInfo && pathInfo.description) || '게시판'} />
-      {/* 실시간 접속자 박스 */}
-      <Box w={DEFAULT_WIDTH} padding={`10px ${DEFAULT_PAGE_PADDING}`}>
-        <Text
-          fontSize="1.6rem"
-          fontWeight="semibold"
-          color="black"
-          cursor="default"
-          mb="10px"
-        >
-          실시간 접속자
-        </Text>
-        {onlineUsersListData && !onlineUsersListData.length ? (
-          <Text
-            fontSize="1.2rem"
-            fontWeight="medium"
-            cursor="default"
-            mb="10px"
-          >
-            접속 중인 사용자가 없습니다.
-          </Text>
-        ) : (
-          onlineUsersListData?.map((onlineUser) => (
-            <OnlineUsers
-              key={onlineUser._id}
-              username={onlineUser.username}
-              image={onlineUser.image}
-            />
-          ))
-        )}
-        <Divider mt="13px" color="gray.450" />
-      </Box>
-      {/* 실시간 접속자 박스 */}
-      <BoardPostList />
+      <OnlineUsers />
+      <BoardPostList channelId={(pathInfo && pathInfo._id) || ''} />
       <WriteButton />
-      <Footer />
+      <Footer position="sticky" bottom="0" />
     </>
   );
 };

--- a/src/pages/BoardPage/index.tsx
+++ b/src/pages/BoardPage/index.tsx
@@ -7,17 +7,17 @@ import BoardPostList from '@/pages/BoardPage/BoardPostList';
 import { useChannelList } from '@/hooks/useChannelList';
 
 const BoardPage = () => {
-  const { channelListData } = useChannelList();
-  const location = useLocation();
+  const { channelListData = [] } = useChannelList();
+  const { pathname } = useLocation();
   const pathInfo = channelListData?.filter(
-    (channel) => channel.name === location.pathname.split('/')[2],
+    (channel) => channel.name === pathname.split('/')[2],
   )[0];
 
   return (
     <>
-      <PageHeader pageName={(pathInfo && pathInfo.description) || '게시판'} />
+      <PageHeader pageName={pathInfo.description} />
       <OnlineUsers />
-      <BoardPostList channelId={(pathInfo && pathInfo._id) || ''} />
+      <BoardPostList channelId={pathInfo._id} />
       <WriteButton />
       <Footer position="sticky" bottom="0" />
     </>


### PR DESCRIPTION
## 작업 사항

- BoardPage에서 게시글을 불러올 때 사용하던 `TEST_CHANNEL_ID` 를 제거하고, DB에 등록된 채널의 id를 사용하도록 수정했습니다.
- BoardPage에서 스타일을 수정했습니다.

## 관련 이슈

<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point

많은 내용이 추가되진 않았지만 `BoardPage > index.tsx` 부분에서 
`<BoardPostList channelId={(pathInfo && pathInfo._id) || ''} />` 이 조금 거슬릴 것 같습니다.. `|| ' '`을 추가하지 않는다면 `pathInfo는 undefined일 수 있습니다.` 라는 에러가 뜨고, `BoardPostList` 안에 type 지정하는 곳에서 `string || undefined` 를 넣자니 애매해서 일단은 || 연산자를 사용하였습니다. 해결 방법에는 어떤 것이 있을까요 ?

## 참고사항

봐주실 코드의 양은 많지 않습니다 !