### PR TITLE
[Fix] 회원가입 시(네임 필드에 채널 추가 했습니다.)

### DIFF
--- a/src/apis/channel.ts
+++ b/src/apis/channel.ts
@@ -1,8 +1,15 @@
-import { getRequest } from './instance';
-import { Channel } from './type';
+import { getRequest, postRequest } from './instance';
+import { Channel, CreateChannelRequestBody } from './type';
 export const getChannelList = async () =>
   await getRequest<Channel[]>('/channels');
 
 /**channelName 값이 한글일 경우, 인코딩 필요**/
 export const getChannel = async (channelName: string) =>
   await getRequest<Channel[]>(`/channels/${channelName}`);
+
+export const createChannel = async (username: string) =>
+  await postRequest<Channel, CreateChannelRequestBody>('/channels/create', {
+    authRequired: true,
+    description: `${username}님의 타이머 채널입니다.`,
+    name: `${username}`,
+  });

--- a/src/apis/type.ts
+++ b/src/apis/type.ts
@@ -30,6 +30,12 @@ export interface Channel {
   updatedAt: string;
 }
 
+export interface CreateChannelRequestBody {
+  authRequired: boolean;
+  description: string;
+  name: string;
+}
+
 export interface Post {
   likes: Like[]; //likes의 길이로 like 수 알 수 있음
   comments: Comment[];

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -87,16 +87,11 @@ export const useSignUp = ({
         ...userInfo,
         fullName: JSON.stringify({ name: fullName, timerChannelId: id }),
       });
-      setItem(LOGIN_TOKEN, data.token);
 
       return data;
     },
     {
-      onSuccess: (data) => {
-        if (onSuccessFn) {
-          onSuccessFn(data);
-        }
-      },
+      onSuccess: (data) => onSuccessFn?.(data),
       onError: (error: AxiosError) => {
         if (onErrorFn) {
           onErrorFn(error);

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -23,8 +23,9 @@ import { preparing } from './preparing';
 import { isValueUniqueInArray } from '@/utils/isValueUniqueInArray';
 import { useGetUsersList } from '@/hooks/useUser';
 import { useLogin } from '@/hooks/useAuth';
-import { LOGINID_SAVEKEY } from '@/constants/user';
-import { getItem } from '@/utils/storage';
+import { LOGINID_SAVEKEY, LOGIN_TOKEN } from '@/constants/user';
+import { getItem, removeItem } from '@/utils/storage';
+import { useEffect } from 'react';
 
 const loginInputList: LoginInputProperty[] = [
   {
@@ -62,6 +63,12 @@ const socialLoginList = [
 const Login = () => {
   const navigate = useNavigate();
   const location = useLocation();
+
+  useEffect(() => {
+    if (getItem(LOGIN_TOKEN, '')) {
+      removeItem(LOGIN_TOKEN);
+    }
+  }, []);
 
   const {
     register,


### PR DESCRIPTION
## 작업 사항
- 회원 가입 시 fullName 필드에 { name: "이름" , channelId: "채널 ID"} 추가
- 회원가입 시 페이지 접속 시 관리자 계정 로그인
- 회원가입 페이지에서 다른 페이지로 이동 시 관리자 인증 토큰 제거
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#100 
<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point
- 채널 생성 시 관리자 인증이 필요하여 임의로 회원가입 페이지 접근 시 관리자 로그인을 진행했습니다.
- 이후 해당 페이지에서 다른 페이지로 이동할 때 인증 토큰을 제거했습니다.
- 해당 페이지에서 회원가입 시 회원 로그인 후 이전 페이지로 이동시켰습니다.
- `useEffect` 사용을 많이 했는데, 이렇게 처리해도 괜찮을까요?? 좋은 방법이 있다면 제안 주시면 수정하도록 하겠습니다.
