### PR TITLE
[Fix] UpdateUserInfo(회원정보 수정) 페이지 - fullName 구조 변경으로 인한 수정

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -101,10 +101,16 @@ export const useUpdateInfo = ({
 }: UpdateUserInfoProps) => {
   return useMutation(
     async () => {
-      const { fullName, username, password } = newUserInfo;
+      const { fullName, username, password, timerChannelId } = newUserInfo;
 
       // 1차 내 정보 변경
-      await changeUserName({ fullName, username });
+      await changeUserName({
+        fullName: JSON.stringify({
+          name: fullName,
+          timerChannelId,
+        }),
+        username,
+      });
       // // 2차 비밀번호 변경
       await changePassword(password);
 

--- a/src/pages/MyPage/Account/index.tsx
+++ b/src/pages/MyPage/Account/index.tsx
@@ -14,14 +14,15 @@ const Account = () => {
   }
 
   const { image, email, fullName, username } = myInfo;
-
+  const { name, timerChannelId } = JSON.parse(fullName);
   return (
     <>
       <UpdateUserInfo
         image={image}
         email={email}
-        fullName={fullName}
+        fullName={name}
         username={username}
+        timerChannelId={timerChannelId}
       />
     </>
   );

--- a/src/pages/MyPage/UpdateUserInfo/index.tsx
+++ b/src/pages/MyPage/UpdateUserInfo/index.tsx
@@ -24,6 +24,7 @@ interface userInfoTypes {
   email: string;
   fullName: string;
   username: string;
+  timerChannelId: string;
 }
 
 const UpdateUserInfo = ({
@@ -31,6 +32,7 @@ const UpdateUserInfo = ({
   email,
   fullName,
   username,
+  timerChannelId,
 }: userInfoTypes) => {
   const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
   const [profilePreview, setProfilePreview] = useState<string>(image || '');
@@ -59,7 +61,7 @@ const UpdateUserInfo = ({
   const { mutate } = useUpdateInfo({
     onSuccessFn,
     profileImageFile,
-    newUserInfo: getValues(),
+    newUserInfo: { ...getValues(), timerChannelId },
   });
 
   // 프로필 이미지 변경

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -27,6 +27,7 @@ export interface UserInfoInput {
   username: string;
   password: string;
   passwordConfirm: string;
+  timerChannelId?: string;
 }
 
 export interface UserResponse {


### PR DESCRIPTION
## 작업 사항
- Account 페이지에서 **나의 정보를 가지고 올 때 JSON화 되어 있는 fullName을 `JSON.parse`로 가지고 옵니다.**
  - 데이터를 가지고 온 뒤 fullName **내부에 있는 `name, timerChannelId` 값을 `UpdateUserInfo` 페이지에 props로 전달**합니다.
- `UpdateUserInfo` 페이지에서 회원정보 수정할 때 **`fullName` 구조에 맞게 변경해서 `JSON.stringify`로 데이터를 전달**합니다. (fullName: {name, timerChannelId)
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#102 
<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point
수정하기 전 회원가입한 유저들은 fullName 필드가 string이기 때문에 회원 데이터를 초기화하지 않고 merge 하면 에러가 발생할 수 있습니다.
<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->
