### PR TITLE
[Fix] useTodayTimerPost내부 날짜비교로직 수정 (간단)

### DIFF
--- a/src/hooks/useTodayTimePost.ts
+++ b/src/hooks/useTodayTimePost.ts
@@ -12,11 +12,23 @@ export const useTodayTimePost = (channelId: string) => {
         errorMessage: '오늘의 타이머 게시글 가져오는 도중 오류발생',
       },
       select: (posts) =>
-        posts.filter((post) => {
+        posts?.filter(({ createdAt }) => {
           // toLocaleDateString으로 YYYY-M-D(예시 2024-1-8)로 변환 후
           // 포스트 createdAt(YYYY-M-DTHH:MM:SS)로 넘어온 값을 T기준으로 잘라서 비교
-          const currentDate = new Date().toLocaleDateString('en-CA');
-          return post.createdAt.split('T')[0] === currentDate;
+          const currentDate = new Date().toLocaleDateString('en-CA', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          });
+          const parsedKrTimePostDate = new Date(createdAt).toLocaleDateString(
+            'en-CA',
+            {
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+            },
+          );
+          return currentDate === parsedKrTimePostDate;
         })?.[0],
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
## 작업 사항

- [ ] createdAt과 오늘 날짜 비교를 그냥 하던걸 한국시간 기준으로 비교하게 변경

## 관련 이슈

#107 

## PR Point

- new Date()에 createAt값을 넣어 한국 시간으로 만들어 준 후, toLocaleString을 이용하여 `YYYY-MM-DD`형태로 만들어준 뒤 비교했습니다

## 참고사항

짧습니다
