### PR TITLE
[Feature] Grass 컴포넌트 제작

### DIFF
--- a/src/components/Grass/GrassCell.tsx
+++ b/src/components/Grass/GrassCell.tsx
@@ -1,0 +1,18 @@
+import { Box, BoxProps } from '@chakra-ui/react';
+
+interface GrassCellProps extends BoxProps {
+  percentage: number; //0, 0.25, 5, 0.75, 1
+}
+
+const GrassCell = ({ percentage = 0, ...props }: GrassCellProps) => {
+  return (
+    <Box
+      bg={`rgba(255,0,0, ${percentage})`}
+      border="1px solid black"
+      size="5px"
+      {...props}
+    />
+  );
+};
+
+export default GrassCell;

--- a/src/components/Grass/GrassCell.tsx
+++ b/src/components/Grass/GrassCell.tsx
@@ -9,7 +9,7 @@ const GrassCell = ({ percentage = 0, ...props }: GrassCellProps) => {
     <GridItem
       bg={`rgba(255,0,0, ${percentage})`}
       border="1px solid black"
-      boxSize="50px"
+      boxSize="20px"
       {...props}
     />
   );

--- a/src/components/Grass/GrassCell.tsx
+++ b/src/components/Grass/GrassCell.tsx
@@ -1,17 +1,26 @@
 import { GridItem, GridItemProps } from '@chakra-ui/react';
+import React, { ForwardedRef } from 'react';
 
 interface GrassCellProps extends GridItemProps {
   percentage: number; //0, 0.25, 5, 0.75, 1
 }
 
-const GrassCell = ({ percentage = 0, ...props }: GrassCellProps) => {
-  return (
-    <GridItem
-      bg={percentage ? `rgba(255,0,0, ${percentage})` : 'gray.300'}
-      boxSize="20px"
-      {...props}
-    />
-  );
-};
+const GrassCell = React.forwardRef(
+  (
+    { percentage = 0, ...props }: GrassCellProps,
+    ref: ForwardedRef<ReturnType<typeof GridItem>>,
+  ) => {
+    return (
+      <GridItem
+        ref={ref}
+        bg={percentage ? `rgba(255,0,0, ${percentage})` : 'gray.300'}
+        boxSize="20px"
+        {...props}
+      />
+    );
+  },
+);
+
+GrassCell.displayName = 'GrassCell';
 
 export default GrassCell;

--- a/src/components/Grass/GrassCell.tsx
+++ b/src/components/Grass/GrassCell.tsx
@@ -1,15 +1,15 @@
-import { Box, BoxProps } from '@chakra-ui/react';
+import { GridItem, GridItemProps } from '@chakra-ui/react';
 
-interface GrassCellProps extends BoxProps {
+interface GrassCellProps extends GridItemProps {
   percentage: number; //0, 0.25, 5, 0.75, 1
 }
 
 const GrassCell = ({ percentage = 0, ...props }: GrassCellProps) => {
   return (
-    <Box
+    <GridItem
       bg={`rgba(255,0,0, ${percentage})`}
       border="1px solid black"
-      size="5px"
+      boxSize="50px"
       {...props}
     />
   );

--- a/src/components/Grass/GrassCell.tsx
+++ b/src/components/Grass/GrassCell.tsx
@@ -7,8 +7,7 @@ interface GrassCellProps extends GridItemProps {
 const GrassCell = ({ percentage = 0, ...props }: GrassCellProps) => {
   return (
     <GridItem
-      bg={`rgba(255,0,0, ${percentage})`}
-      border="1px solid black"
+      bg={percentage ? `rgba(255,0,0, ${percentage})` : 'gray.300'}
       boxSize="20px"
       {...props}
     />

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -9,9 +9,23 @@ interface GrassProps extends GridProps {
 const DUMMY_DATA = [
   { time: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
   { time: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
-  { time: '06:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
+  { time: '05:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
   { time: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
 ];
+
+const getGrassPercentage = (value: number, standard: number = 12) => {
+  const flooredStandard = Math.floor(standard / 4);
+  if (value < flooredStandard) {
+    return 0.25;
+  }
+  if (value < flooredStandard * 2) {
+    return 0.5;
+  }
+  if (value < flooredStandard * 3) {
+    return 0.75;
+  }
+  return 1;
+};
 
 const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
   const today = new Date();
@@ -24,7 +38,8 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
   const thisMonthTimerData = useMemo(() => {
     const tempData = Array(lastDay).fill(0);
 
-    timerPosts.forEach(({ createdAt }) => {
+    timerPosts.forEach(({ time, createdAt }) => {
+      const [hours] = time.split(':').map(Number);
       const [, , createdDay] = new Date(createdAt)
         .toLocaleDateString('en-CA', {
           year: 'numeric',
@@ -34,7 +49,7 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
         .split('-');
 
       //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
-      tempData[+createdDay - 1] = 1;
+      tempData[+createdDay - 1] = { percentage: getGrassPercentage(hours) };
     });
 
     return tempData;
@@ -42,10 +57,10 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
 
   return (
     <Grid templateColumns="repeat(7, fit-content(20px))" gap="5px">
-      {thisMonthTimerData.map((isRecorded, index) => (
+      {thisMonthTimerData.map(({ percentage }, index) => (
         <GrassCell
           key={`day-${index}`}
-          percentage={isRecorded ? 1 : 0}
+          percentage={percentage}
           borderRadius="2px"
         />
       ))}

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -6,12 +6,15 @@ interface GrassProps extends GridProps {
   timerPosts: Post[];
 }
 
-/* 
+const DUMMY_DATA = [
+  { title: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
+  { title: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
+  { title: '06:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
+  { title: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
+];
 
-[{1월1일자 타이머},{1월 3일자 타이머}] 이런식으로 getPostListByChannel로 가져올텐데, 이걸 가공해서 써야함.
-*/
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const Grass = ({ timerPosts }: GrassProps) => {
+const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
   const today = new Date();
   const lastDay = new Date(
     today.getFullYear(),

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,9 +1,8 @@
 import { Grid, GridProps } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
-import { Post } from '@/apis/type';
 
 interface GrassProps extends GridProps {
-  timerPosts: Post[];
+  timerPosts: { title: string; createdAt: string }[]; // 추후 Post[]로 변경필요
 }
 
 const DUMMY_DATA = [
@@ -13,7 +12,6 @@ const DUMMY_DATA = [
   { title: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
   const today = new Date();
   const lastDay = new Date(
@@ -21,17 +19,28 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
     today.getMonth() + 1,
     0,
   ).getDate();
-  //게시글 filter로 뽑아와서 1월달 글 존재하면 percentage계산해서 배열화하면 됨
-  const thisMonthTimerData = [...Array(lastDay)];
+  //회고 게시글을 이번 달 기준으로 filter해서 가져온다. 글 존재하면 percentage계산해서 배열화하면 됨
+  const thisMonthTimerData = Array(lastDay).fill(0);
+  timerPosts.forEach(({ createdAt }) => {
+    const [, , createdDay] = new Date(createdAt)
+      .toLocaleDateString('en-CA', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      })
+      .split('-');
+
+    //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
+    thisMonthTimerData[+createdDay - 1] = 1;
+  });
   return (
-    <Grid
-      templateColumns="repeat(7, fit-content(20px))"
-      gap={2}
-      p={4}
-      maxW="428px"
-    >
-      {thisMonthTimerData.map((_, index) => (
-        <GrassCell key={`day-${index}`} percentage={1} />
+    <Grid templateColumns="repeat(7, fit-content(20px))" gap="5px">
+      {thisMonthTimerData.map((isRecorded, index) => (
+        <GrassCell
+          key={`day-${index}`}
+          percentage={isRecorded ? 1 : 0}
+          borderRadius="2px"
+        />
       ))}
     </Grid>
   );

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,24 +1,11 @@
 import { Grid, GridProps, Tooltip } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
 import { useMemo } from 'react';
+import { calcGrassPercentage } from '@/utils/calcGrassPercentage';
 
 interface GrassProps extends GridProps {
-  timerPosts: { time: string; createdAt: string }[]; // 추후 Post[]로 변경필요
+  timerPosts: { time: string; createdAt: string }[]; // 추후 TimerPost[]로 변경필요
 }
-
-const getGrassPercentage = (value: number, standard: number = 12) => {
-  const flooredStandard = Math.floor(standard / 4);
-  if (value < flooredStandard) {
-    return 0.25;
-  }
-  if (value < flooredStandard * 2) {
-    return 0.5;
-  }
-  if (value < flooredStandard * 3) {
-    return 0.75;
-  }
-  return 1;
-};
 
 const Grass = ({ timerPosts = [] }: GrassProps) => {
   const today = new Date();
@@ -43,7 +30,7 @@ const Grass = ({ timerPosts = [] }: GrassProps) => {
 
       //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
       tempData[+createdDay - 1] = {
-        percentage: getGrassPercentage(hours),
+        percentage: calcGrassPercentage(hours),
         time: `${createdYear}년 ${createdMonth}월 ${createdDay}일`,
       };
     });

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,3 +1,7 @@
-const Grass = () => {};
+import { Container } from '@chakra-ui/react';
+
+const Grass = () => {
+  return <Container>나는 그래스</Container>;
+};
 
 export default Grass;

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,7 +1,27 @@
-import { Container } from '@chakra-ui/react';
+import { Grid } from '@chakra-ui/react';
+import GrassCell from './GrassCell';
 
 const Grass = () => {
-  return <Container>나는 그래스</Container>;
+  const today = new Date();
+  const lastDay = new Date(
+    today.getFullYear(),
+    today.getMonth() + 1,
+    0,
+  ).getDate();
+  //게시글 filter로 뽑아와서 1월달 글 존재하면 percentage계산해서 배열화하면 됨
+  const thisMonthTimerData = [...Array(lastDay)];
+  return (
+    <Grid
+      templateColumns="repeat(7, fit-content(20px))"
+      gap={2}
+      p={4}
+      maxW="428px"
+    >
+      {thisMonthTimerData.map((_, index) => (
+        <GrassCell key={`day-${index}`} percentage={1} />
+      ))}
+    </Grid>
+  );
 };
 
 export default Grass;

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridProps } from '@chakra-ui/react';
+import { Grid, GridProps, Tooltip } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
 import { useMemo } from 'react';
 
@@ -40,7 +40,7 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
 
     timerPosts.forEach(({ time, createdAt }) => {
       const [hours] = time.split(':').map(Number);
-      const [, , createdDay] = new Date(createdAt)
+      const [createdYear, createdMonth, createdDay] = new Date(createdAt)
         .toLocaleDateString('en-CA', {
           year: 'numeric',
           month: '2-digit',
@@ -49,7 +49,10 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
         .split('-');
 
       //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
-      tempData[+createdDay - 1] = { percentage: getGrassPercentage(hours) };
+      tempData[+createdDay - 1] = {
+        percentage: getGrassPercentage(hours),
+        time: `${createdYear}년 ${createdMonth}월 ${createdDay}일`,
+      };
     });
 
     return tempData;
@@ -57,12 +60,10 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
 
   return (
     <Grid templateColumns="repeat(7, fit-content(20px))" gap="5px">
-      {thisMonthTimerData.map(({ percentage }, index) => (
-        <GrassCell
-          key={`day-${index}`}
-          percentage={percentage}
-          borderRadius="2px"
-        />
+      {thisMonthTimerData.map(({ percentage, time }, index) => (
+        <Tooltip key={`day-${index}`} label={time ? time : '회고 기록 없음'}>
+          <GrassCell percentage={percentage} borderRadius="2px" />
+        </Tooltip>
       ))}
     </Grid>
   );

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,5 +1,6 @@
 import { Grid, GridProps } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
+import { useMemo } from 'react';
 
 interface GrassProps extends GridProps {
   timerPosts: { time: string; createdAt: string }[]; // 추후 Post[]로 변경필요
@@ -20,20 +21,24 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
     0,
   ).getDate();
   //회고 게시글을 이번 달 기준으로 filter해서 가져온다. 글 존재하면 percentage계산해서 배열화하면 됨
-  const thisMonthTimerData = Array(lastDay).fill(0);
+  const thisMonthTimerData = useMemo(() => {
+    const tempData = Array(lastDay).fill(0);
 
-  timerPosts.forEach(({ createdAt }) => {
-    const [, , createdDay] = new Date(createdAt)
-      .toLocaleDateString('en-CA', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-      })
-      .split('-');
+    timerPosts.forEach(({ createdAt }) => {
+      const [, , createdDay] = new Date(createdAt)
+        .toLocaleDateString('en-CA', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        })
+        .split('-');
 
-    //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
-    thisMonthTimerData[+createdDay - 1] = 1;
-  });
+      //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
+      tempData[+createdDay - 1] = 1;
+    });
+
+    return tempData;
+  }, [timerPosts, lastDay]);
 
   return (
     <Grid templateColumns="repeat(7, fit-content(20px))" gap="5px">

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,7 +1,17 @@
-import { Grid } from '@chakra-ui/react';
+import { Grid, GridProps } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
+import { Post } from '@/apis/type';
 
-const Grass = () => {
+interface GrassProps extends GridProps {
+  timerPosts: Post[];
+}
+
+/* 
+
+[{1월1일자 타이머},{1월 3일자 타이머}] 이런식으로 getPostListByChannel로 가져올텐데, 이걸 가공해서 써야함.
+*/
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Grass = ({ timerPosts }: GrassProps) => {
   const today = new Date();
   const lastDay = new Date(
     today.getFullYear(),

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -1,0 +1,3 @@
+const Grass = () => {};
+
+export default Grass;

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -6,13 +6,6 @@ interface GrassProps extends GridProps {
   timerPosts: { time: string; createdAt: string }[]; // 추후 Post[]로 변경필요
 }
 
-const DUMMY_DATA = [
-  { time: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
-  { time: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
-  { time: '05:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
-  { time: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
-];
-
 const getGrassPercentage = (value: number, standard: number = 12) => {
   const flooredStandard = Math.floor(standard / 4);
   if (value < flooredStandard) {
@@ -27,7 +20,7 @@ const getGrassPercentage = (value: number, standard: number = 12) => {
   return 1;
 };
 
-const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
+const Grass = ({ timerPosts = [] }: GrassProps) => {
   const today = new Date();
   const lastDay = new Date(
     today.getFullYear(),

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -2,14 +2,14 @@ import { Grid, GridProps } from '@chakra-ui/react';
 import GrassCell from './GrassCell';
 
 interface GrassProps extends GridProps {
-  timerPosts: { title: string; createdAt: string }[]; // 추후 Post[]로 변경필요
+  timerPosts: { time: string; createdAt: string }[]; // 추후 Post[]로 변경필요
 }
 
 const DUMMY_DATA = [
-  { title: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
-  { title: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
-  { title: '06:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
-  { title: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
+  { time: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
+  { time: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
+  { time: '06:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
+  { time: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
 ];
 
 const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
@@ -21,6 +21,7 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
   ).getDate();
   //회고 게시글을 이번 달 기준으로 filter해서 가져온다. 글 존재하면 percentage계산해서 배열화하면 됨
   const thisMonthTimerData = Array(lastDay).fill(0);
+
   timerPosts.forEach(({ createdAt }) => {
     const [, , createdDay] = new Date(createdAt)
       .toLocaleDateString('en-CA', {
@@ -33,6 +34,7 @@ const Grass = ({ timerPosts = DUMMY_DATA }: GrassProps) => {
     //0번 인덱스 기준이라 날짜에서 1을 빼줍니다
     thisMonthTimerData[+createdDay - 1] = 1;
   });
+
   return (
     <Grid templateColumns="repeat(7, fit-content(20px))" gap="5px">
       {thisMonthTimerData.map((isRecorded, index) => (

--- a/src/stories/components/Grass/GrassCell.stories.ts
+++ b/src/stories/components/Grass/GrassCell.stories.ts
@@ -1,0 +1,19 @@
+import GrassCell from '@/components/Grass/GrassCell';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof GrassCell> = {
+  component: GrassCell,
+  argTypes: {
+    percentage: {
+      control: 'radio',
+      options: [0, 0.25, 0.5, 0.75, 1],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GrassCell>;
+
+export const Deafult: Story = {
+  args: {},
+};

--- a/src/stories/components/Grass/index.stories.ts
+++ b/src/stories/components/Grass/index.stories.ts
@@ -1,0 +1,14 @@
+import Grass from '@/components/Grass';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Grass> = {
+  component: Grass,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Grass>;
+
+export const Deafult: Story = {
+  args: {},
+};

--- a/src/stories/components/Grass/index.stories.ts
+++ b/src/stories/components/Grass/index.stories.ts
@@ -3,12 +3,23 @@ import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Grass> = {
   component: Grass,
-  argTypes: {},
+  argTypes: {
+    timerPosts: {
+      control: 'array',
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof Grass>;
 
 export const Deafult: Story = {
-  args: {},
+  args: {
+    timerPosts: [
+      { time: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' },
+      { time: '02:00:00', createdAt: '2024-01-04T20:48:19.816Z' },
+      { time: '05:07:00', createdAt: '2024-01-05T20:48:19.816Z' },
+      { time: '12:07:00', createdAt: '2024-01-10T20:48:19.816Z' },
+    ],
+  },
 };

--- a/src/utils/calcGrassPercentage.test.ts
+++ b/src/utils/calcGrassPercentage.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { calcGrassPercentage } from './calcGrassPercentage';
+
+test('calculate grass percentage from time', () => {
+  expect(calcGrassPercentage(4)).toBe(0.5);
+  expect(calcGrassPercentage(4, 20)).toBe(0.25);
+});

--- a/src/utils/calcGrassPercentage.ts
+++ b/src/utils/calcGrassPercentage.ts
@@ -1,0 +1,16 @@
+export const calcGrassPercentage = (
+  time: number,
+  standardTime: number = 12,
+) => {
+  const flooredStandard = Math.floor(standardTime / 4);
+  if (time < flooredStandard) {
+    return 0.25;
+  }
+  if (time < flooredStandard * 2) {
+    return 0.5;
+  }
+  if (time < flooredStandard * 3) {
+    return 0.75;
+  }
+  return 1;
+};


### PR DESCRIPTION
## 작업 사항
- 잔디를 보여줄 Grass컴포넌트를 제작하였습니다
- 잔디 칸 하나를 이루는 GrassCell컴포넌트를 제작하였습니다(합성 컴포넌트로 해도 좋을거같네요)
- 기준 시간과 현재 시간을 받아서 색 농도 퍼센트를 계산해줄 calcGrassPercentage 유틸함수도 제작하였습니다
- 마우스 올려보면 tooltip에 회고없음 or 회고한 날짜가 나옵니다

## 관련 이슈

#53  입니다

## PR Point

- 받아올때 데이터 구조를 아래처럼 받아오면 좋을거 같았는데, 어떻게 생각하시나요?
`{ time: '06:07:00', createdAt: '2024-01-01T20:48:19.816Z' }` 참고로 time은 회고한 시간입니다 ㅎㅎ
- 기록을 계산하는 로직이 적절한지 궁금합니다.
- 내부에서 new Date를 사용하는데  밖에서 date객체를 받아와서 처리하는건 어떤지 궁금합니다
- 색상도 사용자가 설정할 수 있게하면 좋을거같은데, 어떻게 생각하시나용?

## 참고사항

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/f804b479-7224-4f82-9345-ef0c241391e4)

