### PR TITLE
[Fix] Dday 컴포넌트 버그 수정 및 calculateDday테스트 함수 제작

### DIFF
--- a/src/pages/MainPage/DdayModal/index.tsx
+++ b/src/pages/MainPage/DdayModal/index.tsx
@@ -42,6 +42,17 @@ const DdayModal = ({ isOpen, onClose, setDday }: DdayModalProps) => {
     onClose();
   };
 
+  const getTomorrow = () => {
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+    return tomorrow.toLocaleDateString('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
   return (
     <MyModal
       onClose={onClose}
@@ -94,6 +105,7 @@ const DdayModal = ({ isOpen, onClose, setDday }: DdayModalProps) => {
             p="0 18px"
             h="40px"
             w="150px"
+            min={getTomorrow()}
             {...register('dDayDate', {
               required: 'd-day날짜를 기입해주세요',
             })}

--- a/src/pages/MainPage/DdayModal/index.tsx
+++ b/src/pages/MainPage/DdayModal/index.tsx
@@ -48,7 +48,7 @@ const DdayModal = ({ isOpen, onClose, setDday }: DdayModalProps) => {
       isOpen={isOpen}
       title="D-DAY"
       buttonText="D-day 등록하기"
-      onButtonClick={handleSubmit(() => onSubmit())}
+      onButtonClick={handleSubmit(onSubmit)}
       isCentered
     >
       <form style={{ padding: '0 20px' }}>

--- a/src/pages/MainPage/LoginDday.tsx
+++ b/src/pages/MainPage/LoginDday.tsx
@@ -36,7 +36,7 @@ const LoginDday = () => {
     >
       <Text fontSize="2xl">{dDay.dDayTitle}</Text>
       <Box>
-        <Text fontSize="2xl">{`D-${dDayRemain}`}</Text>
+        <Text fontSize="2xl">{`D-${dDayRemain ? dDayRemain : 'Day'}`}</Text>
         <Text fontSize="lg" fontWeight="normal">
           {dDay.dDayDate}
         </Text>

--- a/src/utils/calculateDday.test.ts
+++ b/src/utils/calculateDday.test.ts
@@ -1,0 +1,9 @@
+import { expect, test, vitest } from 'vitest';
+import { calculateDday } from './calculateDday';
+
+test('calculate d-day by YYYY.MM.DD', () => {
+  const fakeDate = new Date('2024-01-10');
+  vitest.useFakeTimers().setSystemTime(fakeDate);
+  expect(calculateDday('2024.01.18')).toBe(8);
+  expect(calculateDday('2024.01.11')).toBe(1);
+});

--- a/src/utils/calculateDday.ts
+++ b/src/utils/calculateDday.ts
@@ -1,4 +1,5 @@
 export const calculateDday = (dDay: string) => {
-  const timeDiff = Date.parse(dDay) - Date.now();
+  const timeDiff =
+    new Date(dDay).setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0);
   return Math.floor(timeDiff / (1000 * 60 * 60 * 24));
 };


### PR DESCRIPTION
## 작업 사항

- dday 계산로직을 0시0분0초로 변경하여 날짜가 이상하게 나오던 버그 수정하였습니다
- calculatedday 테스트 함수 제작하였습니다
- dday선택할 수 있는 최소 날짜(금일) 설정해두었습니다

## 관련 이슈

#110  입니다

## PR Point

- `getTomorrow`함수로 최솟값을 넣어주고있는데, 불필요한 연산이 계속되는 것 같네요. 날짜가 바뀔때마다 해주면 좋을거같은데...useMemo를 사용하여 인자로 무슨 값을 넘겨주어야할까요
- `toLocaleString`이 메서드 정말 유용하네요 ㅎㅎ

## 참고사항
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/7218690d-e7ba-4ffa-aa0b-5e7ad284884c)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/262698c6-e702-4383-83e4-fb0aa7513496)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/be8f828f-6d2a-454f-a9f5-30483aac1ab2)

