### PR TITLE
[Feature] MainPage 게시판 영역 기능 구현

### DIFF
--- a/src/hooks/useChannels.ts
+++ b/src/hooks/useChannels.ts
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 import { useQuery } from 'react-query';
 
 export const useChannelList = () => {
-  const { data, isError } = useQuery<Channel[], AxiosError>(
+  const { data, isError, isLoading } = useQuery<Channel[], AxiosError>(
     CHANNEL_LIST,
     getChannelList,
     {
@@ -24,7 +24,7 @@ export const useChannelList = () => {
 
   const channelListData = data;
 
-  return { channelListData, isError };
+  return { channelListData, isError, isLoading };
 };
 
 interface useChannelInfoProps {

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -68,6 +68,9 @@ export const useFirstPost = ({
   });
 
   const firstPost = data[0];
+  const firstPostTitle = firstPost
+    ? JSON.parse(firstPost.title).title
+    : '등록된 글이 없습니다.';
 
-  return { firstPost, isError, isLoading };
+  return { firstPostTitle, isError, isLoading };
 };

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -1,7 +1,15 @@
+import { AxiosError } from 'axios';
 import { useMutation, useQuery } from 'react-query';
 import { MYPOST_LIST, POST_DETAIL } from '@/constants/queryKeys';
 import { checkAuthenticated } from '@/apis/authentication';
-import { createPost, editPost, getPostDetail } from '@/apis/post';
+import {
+  createPost,
+  editPost,
+  getPostDetail,
+  ChannelPayload,
+  getPostListByChannel,
+} from '@/apis/post';
+import { Post } from '@/apis/type';
 
 interface PostDetailProps {
   id: string;
@@ -44,4 +52,22 @@ export const useEditPost = ({ onSuccessFn }: PostingProps) => {
     onSuccess: () => onSuccessFn?.(),
     //인증관련 에러일때만 useBoundaryTrue로
   });
+};
+
+export const useFirstPost = ({
+  channelId,
+  offset = 0,
+  limit = 1,
+}: ChannelPayload) => {
+  const {
+    data = [],
+    isError,
+    isLoading,
+  } = useQuery<Post[], AxiosError>(`${channelId}`, async () => {
+    return await getPostListByChannel({ channelId, offset, limit });
+  });
+
+  const firstPost = data[0];
+
+  return { firstPost, isError, isLoading };
 };

--- a/src/pages/MainPage/BoardListPreview.tsx
+++ b/src/pages/MainPage/BoardListPreview.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_WIDTH } from '@/constants/style';
 import { ChevronRightIcon } from '@chakra-ui/icons';
 import { Button, Flex, Spinner, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
@@ -10,7 +9,7 @@ const BoardListPreview = () => {
   const navigate = useNavigate();
 
   return (
-    <Flex maxW={DEFAULT_WIDTH} marginTop="30px" direction="column">
+    <Flex w="100%" marginTop="30px" direction="column">
       <Flex
         borderBottom="1px"
         borderColor="gray.450"

--- a/src/pages/MainPage/BoardListPreview.tsx
+++ b/src/pages/MainPage/BoardListPreview.tsx
@@ -1,24 +1,12 @@
 import { DEFAULT_WIDTH } from '@/constants/style';
 import { ChevronRightIcon } from '@chakra-ui/icons';
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { Button, Flex, Spinner, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
-
-const DUMMY_GALLERY_DATA = [
-  {
-    name: '자유 게시판',
-    posts: ['자유게시판 첫 번째 글', '자유게시판 두 번째 글'],
-  },
-  {
-    name: '목표 달성 & 인증',
-    posts: ['목표 달성 & 인증 첫 번째 글', '목표 달성 & 인증 두 번째 글'],
-  },
-  {
-    name: '정보 공유 게시판',
-    posts: ['정보 공유 게시판 첫 번째 글', '정보 공유 게시판 두 번째 글'],
-  },
-];
+import MainBoardItem from './MainBoardItem';
+import { useChannelList } from '@/hooks/useChannels';
 
 const BoardListPreview = () => {
+  const { channelListData = [], isLoading } = useChannelList();
   const navigate = useNavigate();
 
   return (
@@ -42,23 +30,18 @@ const BoardListPreview = () => {
         </Button>
       </Flex>
       <Flex paddingTop="23px" gap="10px" direction="column">
-        {/* TODO : 게시판 목록을 불러와서 Map으로 뿌려줘야함. */}
-        {DUMMY_GALLERY_DATA.map((item) => (
-          <Flex
-            color="black"
-            alignItems="center"
-            key={item.name}
-            // TODO : 클릭 시 해당 게시판 목록으로 넘어가게 처리 필요.
-            cursor="pointer"
-          >
-            <Box width="130px" fontSize="md" fontWeight="medium">
-              {item.name}
-            </Box>
-            <Box fontSize="sm" fontWeight="medium">
-              {item.posts[0]}
-            </Box>
-          </Flex>
-        ))}
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          channelListData.map((item) => (
+            <MainBoardItem
+              key={item._id}
+              channel={item.name}
+              channelId={item._id}
+              boardName={item.description}
+            />
+          ))
+        )}
       </Flex>
     </Flex>
   );

--- a/src/pages/MainPage/BoardListPreview.tsx
+++ b/src/pages/MainPage/BoardListPreview.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_WIDTH } from '@/constants/style';
 import { ChevronRightIcon } from '@chakra-ui/icons';
 import { Button, Flex, Spinner, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
-import MainBoardItem from './MainBoardItem';
+import BoardListPreviewItem from '@/pages/MainPage/BoardListPreviewItem';
 import { useChannelList } from '@/hooks/useChannels';
 
 const BoardListPreview = () => {
@@ -34,7 +34,7 @@ const BoardListPreview = () => {
           <Spinner />
         ) : (
           channelListData.map((item) => (
-            <MainBoardItem
+            <BoardListPreviewItem
               key={item._id}
               channel={item.name}
               channelId={item._id}

--- a/src/pages/MainPage/BoardListPreviewItem.tsx
+++ b/src/pages/MainPage/BoardListPreviewItem.tsx
@@ -2,19 +2,19 @@ import { useFirstPost } from '@/hooks/usePost';
 import { Box, Flex } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
-interface MainBoardItemProps {
+interface BoardListPreviewItemProps {
   boardName: string;
   channel: string;
   channelId: string;
 }
 
-const MainBoardItem = ({
+const BoardListPreviewItem = ({
   boardName,
   channel,
   channelId,
-}: MainBoardItemProps) => {
+}: BoardListPreviewItemProps) => {
   const navigate = useNavigate();
-  const { firstPost, isLoading } = useFirstPost({ channelId });
+  const { firstPostTitle, isLoading } = useFirstPost({ channelId });
 
   return (
     <Flex
@@ -27,12 +27,10 @@ const MainBoardItem = ({
         {boardName}
       </Box>
       <Box fontSize="1.2rem" fontWeight="medium">
-        {firstPost
-          ? !isLoading && JSON.parse(firstPost.title).title
-          : '등록된 글이 없습니다.'}
+        {!isLoading && firstPostTitle}
       </Box>
     </Flex>
   );
 };
 
-export default MainBoardItem;
+export default BoardListPreviewItem;

--- a/src/pages/MainPage/Dday.tsx
+++ b/src/pages/MainPage/Dday.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_WIDTH } from '@/constants/style';
 import { Box } from '@chakra-ui/react';
 import LoginDday from '@/pages/MainPage/LoginDday';
 import GuestDday from '@/pages/MainPage/GuestDday';
@@ -10,8 +9,8 @@ interface DdayProps {
 const Dday = ({ myInfo = {} }: DdayProps) => {
   return (
     <Box
-      maxW={DEFAULT_WIDTH}
-      marginTop="25px"
+      w="100%"
+      margin="25px 0"
       bg="pink.300"
       borderRadius="5px"
       _hover={{ cursor: 'pointer', bg: '#eb7e7e' }}

--- a/src/pages/MainPage/MainBoardItem.tsx
+++ b/src/pages/MainPage/MainBoardItem.tsx
@@ -1,0 +1,38 @@
+import { useFirstPost } from '@/hooks/usePost';
+import { Box, Flex } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+
+interface MainBoardItemProps {
+  boardName: string;
+  channel: string;
+  channelId: string;
+}
+
+const MainBoardItem = ({
+  boardName,
+  channel,
+  channelId,
+}: MainBoardItemProps) => {
+  const navigate = useNavigate();
+  const { firstPost, isLoading } = useFirstPost({ channelId });
+
+  return (
+    <Flex
+      color="black"
+      alignItems="center"
+      cursor="pointer"
+      onClick={() => navigate(`/board/${channel}`)}
+    >
+      <Box width="140px" fontSize="1.5rem" fontWeight="medium">
+        {boardName}
+      </Box>
+      <Box fontSize="1.2rem" fontWeight="medium">
+        {firstPost
+          ? !isLoading && JSON.parse(firstPost.title).title
+          : '등록된 글이 없습니다.'}
+      </Box>
+    </Flex>
+  );
+};
+
+export default MainBoardItem;

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -8,6 +8,7 @@ import GuestProfile from '@/pages/MainPage/GuestProfile';
 import LoginProfile from '@/pages/MainPage/LoginProfile';
 import Dday from '@/pages/MainPage/Dday';
 import BoardListPreview from '@/pages/MainPage/BoardListPreview';
+// import Grass from '@/components/Grass';
 
 const MainPage = () => {
   const { data: myInfo } = useMyInfo();
@@ -25,6 +26,7 @@ const MainPage = () => {
         <MainPageBody>
           {myInfo ? <LoginProfile myInfo={myInfo} /> : <GuestProfile />}
           <Dday myInfo={myInfo} />
+          {/* <Grass /> */}
           <BoardListPreview />
         </MainPageBody>
         <Footer position="sticky" bottom="0" />
@@ -36,6 +38,7 @@ const MainPage = () => {
 const MainPageBody = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
   height: 100vh;
   padding: 20px ${DEFAULT_PAGE_PADDING};

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,12 +1,13 @@
-import { DEFAULT_WIDTH, DEFAULT_PAGE_PADDING } from '@/constants/style';
 import { Flex } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+import { DEFAULT_PAGE_PADDING } from '@/constants/style';
+import { useMyInfo } from '@/hooks/useAuth';
 import MainHeader from '@/components/MainHeader';
 import Footer from '@/components/Footer';
 import GuestProfile from '@/pages/MainPage/GuestProfile';
 import LoginProfile from '@/pages/MainPage/LoginProfile';
 import Dday from '@/pages/MainPage/Dday';
 import BoardListPreview from '@/pages/MainPage/BoardListPreview';
-import { useMyInfo } from '@/hooks/useAuth';
 
 const MainPage = () => {
   const { data: myInfo } = useMyInfo();
@@ -15,26 +16,34 @@ const MainPage = () => {
     <>
       <Flex
         position="relative"
-        w={DEFAULT_WIDTH}
+        w="100%"
         height="100vh"
         margin="0 auto"
         direction="column"
       >
         <MainHeader />
-        <Flex
-          height="100vh"
-          p={`20px ${DEFAULT_PAGE_PADDING}`}
-          overflowY="auto"
-          direction="column"
-        >
+        <MainPageBody>
           {myInfo ? <LoginProfile myInfo={myInfo} /> : <GuestProfile />}
           <Dday myInfo={myInfo} />
           <BoardListPreview />
-        </Flex>
+        </MainPageBody>
         <Footer position="sticky" bottom="0" />
       </Flex>
     </>
   );
 };
+
+const MainPageBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  padding: 20px ${DEFAULT_PAGE_PADDING};
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
 
 export default MainPage;


### PR DESCRIPTION
## 작업 사항

- 3개의 게시판을 불러왔습니다.
- 각 게시판의 첫 번째 포스트 제목을 출력 해줍니다.
- 게시판 영역을 클릭하면 해당 게시판 (BoardPage)로 이동합니다.

## 관련 이슈

#85 

## PR Point

- `BoardListPreview > MainBoardItem` 로 가는 구조가 너무 복잡해 보일까요 ?
- 네이밍은 이해가 될 정도로 적절한가요 ?

## 참고사항

MainPage에서 `Grass 컴포넌트 (props로 아무것도 안 넘겨줄 때 오류가 발생하여 코드에 추가하진 않았습니다.)` 를 추가하면 아래 사진과 같습니다.

![스크린샷 2024-01-14 오후 5 17 58](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/97944429/6860f102-2e51-49ab-b4f6-a9e932b6f6a3)


