### PR TITLE
[Feature] 회고 작성페이지 제작

### DIFF
--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from 'react-query';
 import { MYPOST_LIST, POST_DETAIL } from '@/constants/queryKeys';
 import { checkAuthenticated } from '@/apis/authentication';
-import { createPost, getPostDetail } from '@/apis/post';
+import { createPost, editPost, getPostDetail } from '@/apis/post';
 
 interface PostDetailProps {
   id: string;
@@ -33,5 +33,12 @@ export const usePosting = ({ onSuccessFn }: PostingProps) => {
     onError: () => {
       alert('글 등록 중 문제가 발생하였습니다. 잠시 후 다시 시도해주세요.');
     },
+  });
+};
+
+export const useEditPost = ({ onSuccessFn }: PostingProps) => {
+  return useMutation(editPost, {
+    onSuccess: () => onSuccessFn?.(),
+    //인증관련 에러일때만 useBoundaryTrue로
   });
 };

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -5,6 +5,7 @@ import { createPost, editPost, getPostDetail } from '@/apis/post';
 
 interface PostDetailProps {
   id: string;
+  enabled?: boolean;
 }
 
 interface PostingProps {
@@ -19,8 +20,10 @@ export const useMyPostList = () => {
   });
 };
 
-export const usePostDetail = ({ id }: PostDetailProps) => {
-  return useQuery(POST_DETAIL, async () => await getPostDetail(id));
+export const usePostDetail = ({ id, enabled }: PostDetailProps) => {
+  return useQuery(POST_DETAIL, async () => await getPostDetail(id), {
+    enabled,
+  });
 };
 
 export const usePosting = ({ onSuccessFn }: PostingProps) => {

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -1,0 +1,101 @@
+import PageHeader from '@/components/PageHeader';
+import {
+  Box,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  HStack,
+  Input,
+  VStack,
+} from '@chakra-ui/react';
+import { Path, RegisterOptions, useForm } from 'react-hook-form';
+
+export interface ReflectionInputTypes {
+  title: string;
+  favorite: string;
+  shame: string;
+  sayToMe: string;
+}
+
+export interface ReflectionInputProps {
+  name: Path<ReflectionInputTypes>;
+  label: string;
+  type: string;
+  required: boolean;
+  placeholder: string;
+  validate?: RegisterOptions;
+}
+
+const ReflectionInputList: ReflectionInputProps[] = [
+  {
+    name: 'title',
+    label: '한 줄 회고',
+    type: 'text',
+    required: true,
+    placeholder: '오늘 하루는 어땠나요?',
+  },
+  {
+    name: 'favorite',
+    label: '오늘 가장 좋았던 일',
+    type: 'text',
+    required: true,
+    placeholder: '오늘 가장 좋았던 일은 무엇인가요?',
+  },
+  {
+    name: 'shame',
+    label: '오늘 아쉬웠던 일',
+    type: 'text',
+    required: true,
+    placeholder: '오늘 아쉬웠던 일은 무엇인가요?',
+  },
+  {
+    name: 'sayToMe',
+    label: '나에게 한마디',
+    type: 'text',
+    required: true,
+    placeholder: '나에게 하고 싶은 말을 적어주세요',
+  },
+];
+
+const ReflectionPostEditPage = () => {
+  const {
+    register,
+    /*     handleSubmit,
+    getValues,
+    formState: { errors, isValid }, */
+  } = useForm<ReflectionInputTypes>();
+
+  return (
+    <>
+      <PageHeader pageName="회고" />
+      <Flex flexDir="column" align="center" w="100%">
+        <HStack>
+          <Box>11</Box>
+          <Box>12</Box>
+          <Box>13</Box>
+          <Box>14</Box>
+        </HStack>
+        <VStack>
+          <form>
+            {ReflectionInputList.map(
+              ({ name, label, type, required, placeholder }) => (
+                <FormControl key={name}>
+                  <FormLabel>{label}</FormLabel>
+                  <Input
+                    type={type}
+                    placeholder={placeholder}
+                    {...register(name, { required })}
+                  />
+                  <FormErrorMessage></FormErrorMessage>
+                </FormControl>
+              ),
+            )}
+          </form>
+        </VStack>
+      </Flex>
+    </>
+  );
+};
+
+export default ReflectionPostEditPage;

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -1,5 +1,6 @@
 import PageHeader from '@/components/PageHeader';
 import { DEFAULT_HEADER_HEIGHT } from '@/constants/style';
+import { getRecentEightDates } from '@/utils/getRecentEightDates';
 import { EditIcon } from '@chakra-ui/icons';
 import {
   Button,
@@ -107,39 +108,18 @@ const ReflectionPostEditPage = () => {
     formState: { errors, isValid },
   } = useForm<ReflectionInputTypes>();
 
-  const onPosting = () => {};
+  /*   const navigate = useNavigate();
 
-  const getDatesAndDays = () => {
-    const today = new Date();
-
-    // 이전 3일과 다음 4일 계산
-    const previousDays = Array.from({ length: 3 }, (_, i) => {
-      const date = new Date(today);
-      date.setDate(today.getDate() - (i + 1));
-      return {
-        date: date.getDate(),
-        day: date.toLocaleDateString('en-US', { weekday: 'short' }),
-      };
-    });
-
-    const nextDays = Array.from({ length: 4 }, (_, i) => {
-      const date = new Date(today);
-      date.setDate(today.getDate() + (i + 1));
-      return {
-        date: date.getDate(),
-        day: date.toLocaleDateString('en-US', { weekday: 'short' }),
-      };
-    });
-
-    return [
-      ...previousDays.reverse(),
-      {
-        date: today.getDate(),
-        day: today.toLocaleDateString('en-US', { weekday: 'short' }),
-      },
-      ...nextDays,
-    ];
+  const onSuccessFn = () => {
+    alert('글 등록 성공!');
+    navigate('/board/reflection');
   };
+
+  const { mutate: onCreatePost } = usePosting({ onSuccessFn });
+
+  const { mutate: onEditPost } = useEditPost({ onSuccessFn }); */
+
+  const onPosting = () => {};
 
   return (
     <>
@@ -151,7 +131,7 @@ const ReflectionPostEditPage = () => {
           h={DEFAULT_HEADER_HEIGHT}
           justify="space-between"
         >
-          {getDatesAndDays().map(({ date, day }, index) => (
+          {getRecentEightDates().map(({ date, day }, index) => (
             <Flex
               key={index}
               flexDir="column"

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -1,12 +1,14 @@
 import PageHeader from '@/components/PageHeader';
+import { EditIcon } from '@chakra-ui/icons';
 import {
   Box,
+  Button,
   Flex,
   FormControl,
   FormErrorMessage,
   FormLabel,
   HStack,
-  Input,
+  Textarea,
   VStack,
 } from '@chakra-ui/react';
 import { Path, RegisterOptions, useForm } from 'react-hook-form';
@@ -22,7 +24,7 @@ export interface ReflectionInputProps {
   name: Path<ReflectionInputTypes>;
   label: string;
   type: string;
-  required: boolean;
+  required: boolean | string;
   placeholder: string;
   validate?: RegisterOptions;
 }
@@ -32,7 +34,7 @@ const ReflectionInputList: ReflectionInputProps[] = [
     name: 'title',
     label: '한 줄 회고',
     type: 'text',
-    required: true,
+    required: '이 칸을 채워주세요',
     placeholder: '오늘 하루는 어땠나요?',
     validate: {
       minLength: {
@@ -49,7 +51,7 @@ const ReflectionInputList: ReflectionInputProps[] = [
     name: 'favorite',
     label: '오늘 가장 좋았던 일',
     type: 'text',
-    required: true,
+    required: '이 칸을 채워주세요',
     placeholder: '오늘 가장 좋았던 일은 무엇인가요?',
     validate: {
       minLength: {
@@ -66,7 +68,7 @@ const ReflectionInputList: ReflectionInputProps[] = [
     name: 'shame',
     label: '오늘 아쉬웠던 일',
     type: 'text',
-    required: true,
+    required: '이 칸을 채워주세요',
     placeholder: '오늘 아쉬웠던 일은 무엇인가요?',
     validate: {
       minLength: {
@@ -83,7 +85,7 @@ const ReflectionInputList: ReflectionInputProps[] = [
     name: 'sayToMe',
     label: '나에게 한마디',
     type: 'text',
-    required: true,
+    required: '이 칸을 채워주세요',
     placeholder: '나에게 하고 싶은 말을 적어주세요',
     validate: {
       minLength: {
@@ -101,38 +103,68 @@ const ReflectionInputList: ReflectionInputProps[] = [
 const ReflectionPostEditPage = () => {
   const {
     register,
-    /*     handleSubmit,
-    getValues,
-    formState: { errors, isValid }, */
+    handleSubmit,
+    formState: { errors, isValid },
   } = useForm<ReflectionInputTypes>();
+
+  const onPosting = () => {};
 
   return (
     <>
       <PageHeader pageName="회고" />
-      <Flex flexDir="column" align="center" w="100%">
-        <HStack>
+      <Flex flexDir="column" align="center" w="100%" flex={1} color="black">
+        <HStack w="100%" p="0 20px">
           <Box>11</Box>
           <Box>12</Box>
           <Box>13</Box>
           <Box>14</Box>
         </HStack>
-        <VStack>
-          <form>
+        <form
+          style={{ width: '100%', flex: 1 }}
+          onSubmit={handleSubmit(onPosting)}
+        >
+          <VStack w="100%" bg="gray.100" p="0 20px" spacing="14px" pt="47px">
             {ReflectionInputList.map(
-              ({ name, label, type, required, placeholder, validate }) => (
-                <FormControl key={name}>
-                  <FormLabel>{label}</FormLabel>
-                  <Input
-                    type={type}
+              ({ name, label, required, placeholder, validate }) => (
+                <FormControl key={name} isInvalid={!!errors?.[name]?.message}>
+                  <FormLabel fontSize="1.6rem" fontWeight="bold">
+                    {label}
+                  </FormLabel>
+                  <Textarea
+                    id={name}
+                    p="10px"
                     placeholder={placeholder}
+                    _placeholder={{ color: 'gray.700' }}
+                    borderRadius="5px"
+                    bg="white"
+                    wordBreak="break-all"
+                    h={name === 'title' ? '50px' : '100px'}
+                    resize="none"
                     {...register(name, { required, ...validate })}
                   />
-                  <FormErrorMessage>{}</FormErrorMessage>
+                  <FormErrorMessage>{errors?.[name]?.message}</FormErrorMessage>
                 </FormControl>
               ),
             )}
-          </form>
-        </VStack>
+            <Button
+              h="50px"
+              mt="27px"
+              mb="128px"
+              w="100%"
+              borderRadius="50px"
+              fontSize="1.6rem"
+              fontWeight="medium"
+              color="white"
+              bg="pink.300"
+              _hover={{ bg: 'pink.400' }}
+              disabled={!isValid}
+              type="submit"
+            >
+              글쓰기
+              <EditIcon ml="5px" />
+            </Button>
+          </VStack>
+        </form>
       </Flex>
     </>
   );

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -14,7 +14,12 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { useEffect } from 'react';
-import { Path, RegisterOptions, useForm } from 'react-hook-form';
+import {
+  Path,
+  RegisterOptions,
+  ValidationValueMessage,
+  useForm,
+} from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 export interface ReflectionInputTypes {
@@ -30,7 +35,7 @@ export interface ReflectionInputProps {
   type: string;
   required: boolean | string;
   placeholder: string;
-  validate?: RegisterOptions;
+  validate: RegisterOptions;
 }
 
 const ReflectionInputList: ReflectionInputProps[] = [
@@ -118,7 +123,7 @@ const ReflectionPostEditPage = () => {
     handleSubmit,
     getValues,
     reset,
-    formState: { errors, isValid },
+    formState: { errors },
   } = useForm<ReflectionInputTypes>();
 
   useEffect(() => {
@@ -158,7 +163,7 @@ const ReflectionPostEditPage = () => {
       onEditPost({
         postId,
         title,
-        //존재하는 게시판이름과 id 1대1 대응하는 자료구조가 필요함
+        //존재하는 게시판이름과 id 1대1 대응하는 자료구조가 있으면 좋을것 같습니다. 일단 임시로 가져와 넣어두었습니다
         channelId: '659f893e93c1183c6d54ac9c',
       });
     } else {
@@ -231,6 +236,11 @@ const ReflectionPostEditPage = () => {
                     wordBreak="break-all"
                     h={name === 'title' ? '50px' : '100px'}
                     resize="none"
+                    maxLength={
+                      validate.maxLength &&
+                      //타입 추론 안되서 as키워드로 강제 변환
+                      +(validate.maxLength as ValidationValueMessage).value
+                    }
                     {...register(name, { required, ...validate })}
                   />
                   <FormErrorMessage>{errors?.[name]?.message}</FormErrorMessage>
@@ -248,7 +258,6 @@ const ReflectionPostEditPage = () => {
               color="white"
               bg="pink.300"
               _hover={{ bg: 'pink.400' }}
-              disabled={!isValid}
               type="submit"
             >
               글쓰기

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -152,14 +152,37 @@ const ReflectionPostEditPage = () => {
           justify="space-between"
         >
           {getDatesAndDays().map(({ date, day }, index) => (
-            <VStack key={index} spacing={0}>
+            <Flex
+              key={index}
+              flexDir="column"
+              justify="center"
+              align="center"
+              w="53px"
+              h="70px"
+              borderRadius="16px"
+              bg={date === new Date().getDate() ? 'pink.100' : 'transparent'}
+              color={date === new Date().getDate() ? 'pink.300' : 'inherit'}
+              position="relative"
+            >
+              {date === new Date().getDate() && (
+                <Text
+                  bg="pink.300"
+                  boxSize="6px"
+                  borderRadius="50%"
+                  position="absolute"
+                  top="8px"
+                />
+              )}
               <Text fontSize="1.8rem" fontWeight="semibold">
                 {date}
               </Text>
-              <Text fontSize="1.2rem" color="gray.800">
+              <Text
+                fontSize="1.2rem"
+                color={date === new Date().getDate() ? 'pink.300' : 'gray.800'}
+              >
                 {day}
               </Text>
-            </VStack>
+            </Flex>
           ))}
         </Flex>
         <form

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -173,7 +173,7 @@ const ReflectionPostEditPage = () => {
                   top="8px"
                 />
               )}
-              <Text fontSize="1.8rem" fontWeight="semibold">
+              <Text fontSize="1.8rem" fontWeight="bold">
                 {date}
               </Text>
               <Text

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -1,13 +1,13 @@
 import PageHeader from '@/components/PageHeader';
+import { DEFAULT_HEADER_HEIGHT } from '@/constants/style';
 import { EditIcon } from '@chakra-ui/icons';
 import {
-  Box,
   Button,
   Flex,
   FormControl,
   FormErrorMessage,
   FormLabel,
-  HStack,
+  Text,
   Textarea,
   VStack,
 } from '@chakra-ui/react';
@@ -109,16 +109,59 @@ const ReflectionPostEditPage = () => {
 
   const onPosting = () => {};
 
+  const getDatesAndDays = () => {
+    const today = new Date();
+
+    // 이전 3일과 다음 4일 계산
+    const previousDays = Array.from({ length: 3 }, (_, i) => {
+      const date = new Date(today);
+      date.setDate(today.getDate() - (i + 1));
+      return {
+        date: date.getDate(),
+        day: date.toLocaleDateString('en-US', { weekday: 'short' }),
+      };
+    });
+
+    const nextDays = Array.from({ length: 4 }, (_, i) => {
+      const date = new Date(today);
+      date.setDate(today.getDate() + (i + 1));
+      return {
+        date: date.getDate(),
+        day: date.toLocaleDateString('en-US', { weekday: 'short' }),
+      };
+    });
+
+    return [
+      ...previousDays.reverse(),
+      {
+        date: today.getDate(),
+        day: today.toLocaleDateString('en-US', { weekday: 'short' }),
+      },
+      ...nextDays,
+    ];
+  };
+
   return (
     <>
       <PageHeader pageName="회고" />
       <Flex flexDir="column" align="center" w="100%" flex={1} color="black">
-        <HStack w="100%" p="0 20px">
-          <Box>11</Box>
-          <Box>12</Box>
-          <Box>13</Box>
-          <Box>14</Box>
-        </HStack>
+        <Flex
+          w="100%"
+          p="0 20px"
+          h={DEFAULT_HEADER_HEIGHT}
+          justify="space-between"
+        >
+          {getDatesAndDays().map(({ date, day }, index) => (
+            <VStack key={index} spacing={0}>
+              <Text fontSize="1.8rem" fontWeight="semibold">
+                {date}
+              </Text>
+              <Text fontSize="1.2rem" color="gray.800">
+                {day}
+              </Text>
+            </VStack>
+          ))}
+        </Flex>
         <form
           style={{ width: '100%', flex: 1 }}
           onSubmit={handleSubmit(onPosting)}

--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -34,6 +34,16 @@ const ReflectionInputList: ReflectionInputProps[] = [
     type: 'text',
     required: true,
     placeholder: '오늘 하루는 어땠나요?',
+    validate: {
+      minLength: {
+        value: 2,
+        message: '최소 2글자 이상 입력해주세요',
+      },
+      maxLength: {
+        value: 20,
+        message: '최대 20글자까지 입력 가능합니다',
+      },
+    },
   },
   {
     name: 'favorite',
@@ -41,6 +51,16 @@ const ReflectionInputList: ReflectionInputProps[] = [
     type: 'text',
     required: true,
     placeholder: '오늘 가장 좋았던 일은 무엇인가요?',
+    validate: {
+      minLength: {
+        value: 1,
+        message: '최소 1글자 이상 입력해주세요',
+      },
+      maxLength: {
+        value: 300,
+        message: '최대 300글자까지 입력 가능합니다',
+      },
+    },
   },
   {
     name: 'shame',
@@ -48,6 +68,16 @@ const ReflectionInputList: ReflectionInputProps[] = [
     type: 'text',
     required: true,
     placeholder: '오늘 아쉬웠던 일은 무엇인가요?',
+    validate: {
+      minLength: {
+        value: 1,
+        message: '최소 1글자 이상 입력해주세요',
+      },
+      maxLength: {
+        value: 300,
+        message: '최대 300글자까지 입력 가능합니다',
+      },
+    },
   },
   {
     name: 'sayToMe',
@@ -55,6 +85,16 @@ const ReflectionInputList: ReflectionInputProps[] = [
     type: 'text',
     required: true,
     placeholder: '나에게 하고 싶은 말을 적어주세요',
+    validate: {
+      minLength: {
+        value: 2,
+        message: '최소 2글자 이상 입력해주세요',
+      },
+      maxLength: {
+        value: 40,
+        message: '최대 40글자까지 입력 가능합니다',
+      },
+    },
   },
 ];
 
@@ -79,15 +119,15 @@ const ReflectionPostEditPage = () => {
         <VStack>
           <form>
             {ReflectionInputList.map(
-              ({ name, label, type, required, placeholder }) => (
+              ({ name, label, type, required, placeholder, validate }) => (
                 <FormControl key={name}>
                   <FormLabel>{label}</FormLabel>
                   <Input
                     type={type}
                     placeholder={placeholder}
-                    {...register(name, { required })}
+                    {...register(name, { required, ...validate })}
                   />
-                  <FormErrorMessage></FormErrorMessage>
+                  <FormErrorMessage>{}</FormErrorMessage>
                 </FormControl>
               ),
             )}

--- a/src/stories/pages/ReflectionPostEditPage/index.stories.tsx
+++ b/src/stories/pages/ReflectionPostEditPage/index.stories.tsx
@@ -1,0 +1,25 @@
+import PageLayout from '@/components/PageLayout';
+import ReflectionPostEditPage from '@/pages/ReflectionPostEditPage';
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  reactRouterNestedAncestors,
+  reactRouterParameters,
+} from 'storybook-addon-react-router-v6';
+
+const meta = {
+  component: ReflectionPostEditPage,
+  argTypes: {},
+  parameters: {
+    reactRouter: reactRouterParameters({
+      routing: reactRouterNestedAncestors(<PageLayout />),
+    }),
+  },
+} satisfies Meta<typeof ReflectionPostEditPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof ReflectionPostEditPage>;
+
+export const Deafult: Story = {
+  args: {},
+};

--- a/src/utils/getRecentEightDates.test.ts
+++ b/src/utils/getRecentEightDates.test.ts
@@ -1,0 +1,17 @@
+import { expect, test, vitest } from 'vitest';
+import { getRecentEightDates } from './getRecentEightDates';
+
+test('get recent eight days. 3 days before and 4 days after including the day', () => {
+  const fakeDate = new Date('Thu Jan 01 2024 18:42:44 GMT+0900 (한국 표준시)');
+  vitest.useFakeTimers().setSystemTime(fakeDate);
+  expect(getRecentEightDates()).toEqual([
+    { date: 29, day: 'Fri' },
+    { date: 30, day: 'Sat' },
+    { date: 31, day: 'Sun' },
+    { date: 1, day: 'Mon' },
+    { date: 2, day: 'Tue' },
+    { date: 3, day: 'Wed' },
+    { date: 4, day: 'Thu' },
+    { date: 5, day: 'Fri' },
+  ]);
+});

--- a/src/utils/getRecentEightDates.ts
+++ b/src/utils/getRecentEightDates.ts
@@ -1,0 +1,31 @@
+export const getRecentEightDates = () => {
+  const today = new Date();
+
+  // 이전 3일과 다음 4일 계산
+  const previousDays = Array.from({ length: 3 }, (_, i) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() - (i + 1));
+    return {
+      date: date.getDate(),
+      day: date.toLocaleDateString('en-US', { weekday: 'short' }),
+    };
+  });
+
+  const nextDays = Array.from({ length: 4 }, (_, i) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() + (i + 1));
+    return {
+      date: date.getDate(),
+      day: date.toLocaleDateString('en-US', { weekday: 'short' }),
+    };
+  });
+
+  return [
+    ...previousDays.reverse(),
+    {
+      date: today.getDate(),
+      day: today.toLocaleDateString('en-US', { weekday: 'short' }),
+    },
+    ...nextDays,
+  ];
+};


### PR DESCRIPTION
## 작업 사항

- 회고 작성 페이지를 제작하였습니다
- usePost파일에 useEidtPost 훅 추가하였습니다
- usePostDetail에 enabled 인자 추가하였습니다. => 특정 값이 존재할때만 쿼리하는 기능입니다
- getRecentEightDates 함수 추가하였습니다. => 당일기준 -3일, +4일 날짜+요일 가져옵니다.
- querystring으로 `id`가 들어오면, usePostDetail을 이용하여 포스팅된 글자를 가져온 뒤, 각 input의 초기값으로 넣어줍니다.
  - 또한 `id`가있으면 글쓰기 버튼 누를시 작성 대신 수정이 됩니다.

## 관련 이슈

#117 

## PR Point

```js
                    maxLength={
                      validate.maxLength &&
                      //타입 추론 안되서 as키워드로 강제 변환
                      +(validate.maxLength as ValidationValueMessage).value
                    }
```
이부분 타입추론, 타입 narrowing이 잘 안되서 as키워드 사용하였는데 좋은 방법 있으면 알려주세용..ㅠㅠ

- 채널id와 채널 제목이 1대1 대응되는 자료구조가 있으면 좋을것 같습니다.
- 인증 관련 에러처리는 전역에서 에러바운더리로 잡기로 하였는데, 이곳에선 어떤 에러처리가 필요할까요?
  - 인증이 되었는데도 에러가 발생했다면 서버문제니 다시 시도하기 정도면 좋을것 같긴 합니다

## 참고사항

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/0f9d258b-75b3-44d6-963e-7ea8fe1c6b6d)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/4fa15420-838b-4163-86cb-b26278b48a0a)