### PR TITLE
[Fix] PostList 버그 수정

### DIFF
--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -5,6 +5,7 @@ import { useQuery } from 'react-query';
 import PostListItem from './PostListItem';
 import { Box, StackDivider, StackProps, VStack } from '@chakra-ui/react';
 import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
+import { calculateTimeDiff } from '@/utils/calculateTimeDiff';
 
 interface PostListProps extends ChannelPayload, StackProps {
   keyword: string;
@@ -46,7 +47,7 @@ const PostList = ({
         <PostListItem
           key={post._id}
           title={post.title}
-          timeAgo="2일 전"
+          timeAgo={calculateTimeDiff(post.createdAt) || '날짜계산 불가'}
           username={post.author.username}
           likeCount={post.likes.length}
           commentCount={post.comments.length}

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -8,7 +8,7 @@ import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
 import { calculateTimeDiff } from '@/utils/calculateTimeDiff';
 
 interface PostListProps extends ChannelPayload, StackProps {
-  keyword: string;
+  keyword?: string;
 }
 
 const PostList = ({
@@ -28,7 +28,11 @@ const PostList = ({
       meta: {
         errorMessage: '게시글 목록 가져올때 에러 발생하였습니다',
       },
-      select: (data) => data.filter((post) => post.title.includes(keyword)),
+      select: (data) => {
+        return keyword
+          ? data.filter((post) => post.title.includes(keyword))
+          : data;
+      },
     },
   );
 

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -11,6 +11,15 @@ interface PostListProps extends ChannelPayload, StackProps {
   keyword?: string;
 }
 
+const checkIsJson = (str: string) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};
+
 const PostList = ({
   keyword,
   channelId,
@@ -50,7 +59,9 @@ const PostList = ({
       {data?.map((post) => (
         <PostListItem
           key={post._id}
-          title={post.title}
+          title={
+            checkIsJson(post.title) ? JSON.parse(post.title).title : post.title
+          }
           timeAgo={calculateTimeDiff(post.createdAt) || '날짜계산 불가'}
           username={post.author.username}
           likeCount={post.likes.length}

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -6,19 +6,11 @@ import PostListItem from './PostListItem';
 import { Box, StackDivider, StackProps, VStack } from '@chakra-ui/react';
 import { DEFAULT_PAGE_PADDING, DEFAULT_WIDTH } from '@/constants/style';
 import { calculateTimeDiff } from '@/utils/calculateTimeDiff';
+import { checkIsJson } from '@/utils/checkIsJson';
 
 interface PostListProps extends ChannelPayload, StackProps {
   keyword?: string;
 }
-
-const checkIsJson = (str: string) => {
-  try {
-    JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-  return true;
-};
 
 const PostList = ({
   keyword,

--- a/src/utils/checkIsJson.test.ts
+++ b/src/utils/checkIsJson.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { checkIsJson } from './checkIsJson';
+
+test('check is this json', () => {
+  expect(checkIsJson('제목입니다')).toBe(false);
+  expect(
+    checkIsJson(
+      JSON.stringify({ title: '제목', content: { a: 1, b: 2, c: 3 } }),
+    ),
+  ).toBe(true);
+});

--- a/src/utils/checkIsJson.ts
+++ b/src/utils/checkIsJson.ts
@@ -1,0 +1,8 @@
+export const checkIsJson = (str: string) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## 작업 사항

- caclulateTimeDiff이용하여 timeAgo(며칠전 등 나타내는 속성)실제 날짜와 비교하게 변경
- keyword 프롭스가 존재하지 않을 시 데이터를 그냥 내보내게 변경
- JSON.parse로 역직렬화 가능한 `post.title`은 역직렬화 하여 제목에 `JSON.parse(post.title).title`을 보여주게 변경

## 관련 이슈

#119 

## PR Point

짧아서 크게 없습니다.
다만 역직렬화 가능한 타입인지 체크할때 try-catch를 이용해야하는게 참 신기하네요 ㅎㅎ

## 참고사항

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/4cbe4b34-8d77-4357-8195-28e0a081523f)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/c3fe55a2-2887-48c2-9d1d-d9d803fd2513)
