### PR TITLE
[Fix] 메인헤더 아이콘 관련 수정 (간단)

### DIFF
--- a/src/components/MainHeader/index.tsx
+++ b/src/components/MainHeader/index.tsx
@@ -5,13 +5,6 @@ import {
   DEFAULT_WIDTH,
 } from '@/constants/style';
 import {
-  BellIcon,
-  ChatIcon,
-  MoonIcon,
-  SearchIcon,
-  SunIcon,
-} from '@chakra-ui/icons';
-import {
   Flex,
   FlexProps,
   Icon,
@@ -20,18 +13,25 @@ import {
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
+import {
+  MdMailOutline,
+  MdOutlineDarkMode,
+  MdOutlineLightMode,
+  MdOutlineNotifications,
+  MdOutlineSearch,
+} from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
 const MainHeader = ({ ...props }: FlexProps) => {
   const { toggleColorMode } = useColorMode();
-  const DarkModeIcon = useColorModeValue(MoonIcon, SunIcon);
+  const DarkModeIcon = useColorModeValue(MdOutlineDarkMode, MdOutlineLightMode);
 
   const navigate = useNavigate();
 
   const BadgedIcon = () => {
     return (
       <Badge count={1}>
-        <BellIcon color="black" boxSize="icon" />
+        <Icon as={MdOutlineNotifications} color="black" boxSize="icon" />
       </Badge>
     );
   };
@@ -43,12 +43,12 @@ const MainHeader = ({ ...props }: FlexProps) => {
       onClick: () => toggleColorMode(),
     },
     {
-      icon: ChatIcon,
+      icon: MdMailOutline,
       description: 'message',
       onClick: () => navigate('/message'),
     },
     {
-      icon: SearchIcon,
+      icon: MdOutlineSearch,
       description: 'search',
       onClick: () => navigate('/search'),
     },

--- a/src/components/MainHeader/index.tsx
+++ b/src/components/MainHeader/index.tsx
@@ -14,15 +14,50 @@ import {
 import {
   Flex,
   FlexProps,
+  Icon,
   IconButton,
   Image,
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 
 const MainHeader = ({ ...props }: FlexProps) => {
   const { toggleColorMode } = useColorMode();
   const DarkModeIcon = useColorModeValue(MoonIcon, SunIcon);
+
+  const navigate = useNavigate();
+
+  const BadgedIcon = () => {
+    return (
+      <Badge count={1}>
+        <BellIcon color="black" boxSize="icon" />
+      </Badge>
+    );
+  };
+
+  const mainHeaderIconPath = [
+    {
+      icon: DarkModeIcon,
+      description: 'toggleDarkMode',
+      onClick: () => toggleColorMode(),
+    },
+    {
+      icon: ChatIcon,
+      description: 'message',
+      onClick: () => navigate('/message'),
+    },
+    {
+      icon: SearchIcon,
+      description: 'search',
+      onClick: () => navigate('/search'),
+    },
+    {
+      icon: BadgedIcon,
+      description: 'notification',
+      onClick: () => navigate('/search'),
+    },
+  ];
 
   return (
     <Flex
@@ -42,35 +77,16 @@ const MainHeader = ({ ...props }: FlexProps) => {
         src="/assets/dopenLogo.svg"
       />
       <Flex gap="20px">
-        <IconButton
-          aria-label="toggleDarkMode"
-          icon={<DarkModeIcon color="black" boxSize="icon" />}
-          bg="transparent"
-          size="md"
-          onClick={toggleColorMode}
-        />
-        <IconButton
-          aria-label="message"
-          icon={<ChatIcon color="black" boxSize="icon" />}
-          bg="transparent"
-          size="md"
-        />
-        <IconButton
-          aria-label="search"
-          icon={<SearchIcon color="black" boxSize="icon" />}
-          bg="transparent"
-          size="md"
-        />
-        <IconButton
-          aria-label="notify"
-          icon={
-            <Badge count={1}>
-              <BellIcon color="black" boxSize="icon" />
-            </Badge>
-          }
-          bg="transparent"
-          size="md"
-        />
+        {mainHeaderIconPath.map(({ icon, onClick, description }) => (
+          <IconButton
+            key={description}
+            bg="transparent"
+            size="md"
+            aria-label={description}
+            icon={<Icon as={icon} color="black" boxSize="icon" />}
+            onClick={onClick}
+          />
+        ))}
       </Flex>
     </Flex>
   );

--- a/src/components/MainHeader/index.tsx
+++ b/src/components/MainHeader/index.tsx
@@ -55,7 +55,7 @@ const MainHeader = ({ ...props }: FlexProps) => {
     {
       icon: BadgedIcon,
       description: 'notification',
-      onClick: () => navigate('/search'),
+      onClick: () => navigate('/notification'),
     },
   ];
 


### PR DESCRIPTION
## 작업 사항

- 메인헤더 상단 아이콘 네비게이팅되게 수정
- 아이콘+클릭이벤트 배열화 하여 map메서드로 뿌려주게 수정
- 아이콘 전부 material design아이콘으로 변경

## 관련 이슈

#121 

## PR Point

간단합니다

## 참고사항

![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/87127340/0448493e-f55a-4497-84c5-87536d664d5f)

