### PR TITLE
[Fix] MyPage(마이페이지) 메뉴 리스트 추가

### DIFF
--- a/src/pages/MyPage/MyPageListItem.tsx
+++ b/src/pages/MyPage/MyPageListItem.tsx
@@ -6,14 +6,20 @@ import { useNavigate } from 'react-router-dom';
 interface MyPageListItemProps {
   icon: IconType;
   title: string;
-  href: string;
+  href?: string;
+  username?: string;
 }
 
-const MyPageListItem = ({ icon, title, href }: MyPageListItemProps) => {
+const MyPageListItem = ({
+  icon,
+  title,
+  href,
+  username,
+}: MyPageListItemProps) => {
   const navigator = useNavigate();
 
   return (
-    <li onClick={() => navigator(href)}>
+    <li onClick={() => navigator(href || `/${username}`)}>
       <Flex alignItems="center">
         <Flex
           alignItems="center"

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -6,6 +6,8 @@ import { removeItem } from '@/utils/storage';
 import { useLogOut, useMyInfo } from '@/hooks/useAuth';
 import MyPageListItem from './MyPageListItem';
 import { MYPAGE_LIST } from './myPageList';
+import PageHeader from '@/components/PageHeader';
+import Footer from '@/components/Footer';
 
 const MyPage = () => {
   const navigator = useNavigate();
@@ -15,53 +17,58 @@ const MyPage = () => {
     navigator('/', { replace: true });
   };
   const { mutate } = useLogOut({ onSuccessFn });
+  const { data: myInfo } = useMyInfo();
 
   const onLogOut = () => {
     mutate();
   };
 
-  const { data: myInfo, isLoading } = useMyInfo();
-
-  if (isLoading || !myInfo) {
-    return <Box>로딩중입니다...</Box>;
-  }
-
   return (
-    <Box w="100%" h="100vh" m="0 auto" textAlign="center" padding="0 20px">
-      <Box>
-        <Box mt={15}>
-          <Avatar
-            w="118px"
-            h="118px"
-            name={myInfo.username + '님의 프로필 이미지입니다.'}
-            src={myInfo.image || 'https://via.placeholder.com/118x118'}
-          />
+    <Box w="100%" h="100vh" m="0 auto" textAlign="center">
+      <PageHeader pageName="마이페이지" />
+      <Box padding="20px" h="calc(100% - 160px)">
+        <Box
+          width="fit-content"
+          margin="15px auto 0"
+          cursor="pointer"
+          onClick={() => navigator(`/${myInfo?.username}`)}
+        >
+          <Box>
+            <Avatar
+              w="118px"
+              h="118px"
+              name={myInfo?.username + '님의 프로필 이미지입니다.'}
+              src={myInfo?.image || 'https://via.placeholder.com/118x118'}
+            />
+          </Box>
+          <ProfileName>{myInfo?.username}</ProfileName>
         </Box>
-        <ProfileName>{myInfo.username}</ProfileName>
+        {MYPAGE_LIST.map((mypage, index) => {
+          return (
+            <MyPageUl key={index}>
+              {mypage.map(({ icon, title, href }, index) => {
+                return (
+                  <MyPageListItem
+                    key={index}
+                    icon={icon}
+                    title={title}
+                    href={href}
+                    username={myInfo?.username}
+                  />
+                );
+              })}
+            </MyPageUl>
+          );
+        })}
+        <MyPageUl>
+          <li onClick={onLogOut}>
+            <Text as="strong" fontSize="lg" color="pink.400">
+              로그아웃
+            </Text>
+          </li>
+        </MyPageUl>
       </Box>
-      {MYPAGE_LIST.map((mypage, index) => {
-        return (
-          <MyPageUl key={index}>
-            {mypage.map(({ icon, title, href }, index) => {
-              return (
-                <MyPageListItem
-                  key={index}
-                  icon={icon}
-                  title={title}
-                  href={href}
-                />
-              );
-            })}
-          </MyPageUl>
-        );
-      })}
-      <MyPageUl>
-        <li onClick={onLogOut}>
-          <Text as="strong" fontSize="lg" color="pink.400">
-            로그아웃
-          </Text>
-        </li>
-      </MyPageUl>
+      <Footer />
     </Box>
   );
 };

--- a/src/pages/MyPage/myPageList.ts
+++ b/src/pages/MyPage/myPageList.ts
@@ -1,7 +1,16 @@
-import { FaUserCircle, FaClipboardList, FaPen } from 'react-icons/fa';
+import {
+  FaUserCircle,
+  FaClipboardList,
+  FaPen,
+  FaAddressCard,
+} from 'react-icons/fa';
 
 export const MYPAGE_LIST = [
   [
+    {
+      icon: FaAddressCard,
+      title: '내 정보 보기',
+    },
     {
       icon: FaUserCircle,
       title: '회원정보 수정',


### PR DESCRIPTION
## 작업 사항
- 프로필 이미지, 닉네임 영역을 클릭하면 내 정보 보기 페이지로 이동하도록 작업 했습니다.
- 메뉴 리스트에 내 정보 보기 리스트를 추가했습니다.
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#132
<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point
마이페이지 리스트에 **내 정보 보기** 페이지를 추가했습니다. (추가로, 프로필 이미지, 닉네임 클릭 시에도 내 정보 보기 페이지로 이동 되도록 링크 추가했습니다.)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_dopen_Hoil/assets/114329713/59872af3-0789-49a9-836d-32815cbd8d86)

<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->
