### PR TITLE
[Fix] 타이머 페이지 버그 수정 및 쿼리 전역 설정 변경 (간단)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,6 +27,7 @@ import ErrorFallback from '@/pages/PostViewPage/ErrorFallback';
 import { useQueryErrorResetBoundary } from 'react-query';
 import { Spinner } from '@chakra-ui/react';
 import ReflectionViewPage from '@/pages/ReflectionViewPage';
+import ReflectionPostEditPage from '@/pages/ReflectionPostEditPage';
 
 const App = () => {
   const { channelListData } = useChannelList();
@@ -48,12 +49,12 @@ const App = () => {
               <Route path="/message" element={<MessageListPage />} />
               <Route path="/message/:userId" element={<MessagePage />} />
               <Route
-                path="/board/:boardName/:postId"
-                element={<PostViewPage />}
-              />
-              <Route
                 path="/board/reflection/:postId"
                 element={<ReflectionViewPage />}
+              />
+              <Route
+                path="/board/:boardName/:postId"
+                element={<PostViewPage />}
               />
               <Route path="/notification" element={<NotificationPage />} />
               <Route path="/timer" element={<TimerPage />} />
@@ -61,6 +62,10 @@ const App = () => {
             <Route path="/:username" element={<UserInfo />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/board" element={<BoardEnterPage />} />
+            <Route
+              path="/board/reflection/post"
+              element={<ReflectionPostEditPage />}
+            />
             {channelListData?.map((board) => (
               <Fragment key={board._id}>
                 <Route path={`/board/${board.name}`} element={<BoardPage />} />

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -63,6 +63,7 @@ const useTimer = ({
     setIsPlay(true);
     const id = setInterval(() => {
       const { total, hours, minutes, seconds } = getTimeRemaining(deadline);
+      setTimer(`${hours}:${minutes}:${seconds}`);
       if (
         limitTime &&
         Date.parse(`1970-01-01T${limitTime}`) -
@@ -81,7 +82,6 @@ const useTimer = ({
         timerEndCallback?.();
         setTimeout(() => setIsTimerEnd(false));
       }
-      setTimer(`${hours}:${minutes}:${seconds}`);
     }, 1000);
 
     setIntervalId.current = id;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
+      refetchOnWindowFocus: false,
     },
   },
   queryCache: new QueryCache({

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -156,7 +156,7 @@ const TimerPage = () => {
   }, []);
 
   return (
-    <Flex flexDir="column" align="center" w="100%" bg="pink.200">
+    <Flex flexDir="column" align="center" w="100%" bg="pink.200" flex={1}>
       <PageHeader pageName="타이머" />
       <Center p="97px 0" position="relative" w="100%">
         <CircularProgress

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useRef } from 'react';
 import { MdPause, MdPlayArrow } from 'react-icons/md';
-import { useMutation } from 'react-query';
+import { UseQueryResult, useMutation } from 'react-query';
 import TimerSettingModal from './TimerSettingModal';
 import { stringTimeToSeconds } from '@/utils/stringTimeToSeconds';
 import { useTodayTimePost } from '@/hooks/useTodayTimePost';
@@ -25,13 +25,8 @@ import { secondsToStringTime } from '@/utils/secondsToStringTime';
 import { convertDateToString } from '@/utils/convertDateToString';
 import { getCurrentStringTime } from '@/utils/getCurrentStringTime';
 import { TIME_OUT_VALUE } from '@/constants/time';
-
-const DUMMY_DATA = {
-  userId: '658b73f0fadd1520147a8d64',
-  email: 'test@test.com',
-  password: '12341234',
-  timerChannelId: '659cbef85b11b0431d028400',
-};
+import { useOutletContext } from 'react-router-dom';
+import { User } from '@/apis/type';
 
 const timerIconStyle: IconButtonProps = {
   position: 'absolute',
@@ -53,11 +48,15 @@ const TimerPage = () => {
     },
   );
 
+  const { data: myInfo, isSuccess } = useOutletContext<UseQueryResult<User>>();
+
+  const { timerChannelId } = isSuccess && JSON.parse(myInfo?.fullName);
+
   const {
     data: todayTimePost,
     refetch,
     isError: isTodayTimePostError,
-  } = useTodayTimePost(DUMMY_DATA.timerChannelId);
+  } = useTodayTimePost(timerChannelId);
 
   const currentTargetTime = useRef(timer);
   const originTargetTime = useRef(timer);
@@ -69,7 +68,7 @@ const TimerPage = () => {
     (time: string) =>
       createPost({
         title: time,
-        channelId: DUMMY_DATA.timerChannelId,
+        channelId: timerChannelId,
       }),
     {
       onSuccess: () => refetch(),
@@ -82,7 +81,7 @@ const TimerPage = () => {
       editPost({
         postId,
         title,
-        channelId: DUMMY_DATA.timerChannelId,
+        channelId: timerChannelId,
       }),
     { onSuccess: () => refetch() },
   );


### PR DESCRIPTION
## 작업 사항

- 타이머가 완료되어도 1초남는 버그 수정
- 쿼리 전역 설정 refetchOnWindowFocus: false,로 변경하였습니다
- reflectionPostEdit라우트 빠져있어서 추가하였습니다

## 관련 이슈

#135 

## PR Point

전역에서 refetchOnWindowFocus: false 쿼리 옵션 주어서 윈도우 포커싱될때 쿼리 안하게 만들었습니다

## 참고사항
