### PR TITLE
[Fix] SearchPage 검색 시 요청이 여러번 들어가는 버그 수정

### DIFF
--- a/src/pages/SearchPage/OptionSelector.tsx
+++ b/src/pages/SearchPage/OptionSelector.tsx
@@ -1,32 +1,43 @@
 import { Channel } from '@/apis/type';
 import { DEFAULT_PAGE_PADDING } from '@/constants/style';
-import { Box, Select, SelectProps } from '@chakra-ui/react';
+import {
+  Box,
+  FormControl,
+  FormErrorMessage,
+  Select,
+  SelectProps,
+} from '@chakra-ui/react';
 import { Dispatch, SetStateAction } from 'react';
 
 interface SearchOptionSelectorProps extends SelectProps {
+  option: string;
   setOption: Dispatch<SetStateAction<string>>;
   channelListData?: Channel[];
 }
 
 const OptionSelector = ({
+  option = '',
   setOption,
   channelListData = [],
   ...props
 }: SearchOptionSelectorProps) => {
   return (
     <Box p={`0 ${DEFAULT_PAGE_PADDING}`}>
-      <Select
-        placeholder="검색 조건"
-        onChange={(e) => setOption(e.target.value)}
-        {...props}
-      >
-        <option value="유저">유저</option>
-        {channelListData?.map((option) => (
-          <option value={option.name} key={option._id}>
-            {option.description}
-          </option>
-        ))}
-      </Select>
+      <FormControl isInvalid={!option}>
+        <Select
+          placeholder="검색 조건"
+          onChange={(e) => setOption(e.target.value)}
+          {...props}
+        >
+          <option value="유저">유저</option>
+          {channelListData?.map((option) => (
+            <option value={option.name} key={option._id}>
+              {option.description}
+            </option>
+          ))}
+        </Select>
+        {!option && <FormErrorMessage>옵션을 선택해주세요.</FormErrorMessage>}
+      </FormControl>
     </Box>
   );
 };

--- a/src/pages/SearchPage/OptionSelector.tsx
+++ b/src/pages/SearchPage/OptionSelector.tsx
@@ -24,11 +24,7 @@ const OptionSelector = ({
   return (
     <Box p={`0 ${DEFAULT_PAGE_PADDING}`}>
       <FormControl isInvalid={!option}>
-        <Select
-          placeholder="검색 조건"
-          onChange={(e) => setOption(e.target.value)}
-          {...props}
-        >
+        <Select onChange={(e) => setOption(e.target.value)} {...props}>
           <option value="유저">유저</option>
           {channelListData?.map((option) => (
             <option value={option.name} key={option._id}>

--- a/src/pages/SearchPage/SearchInput.tsx
+++ b/src/pages/SearchPage/SearchInput.tsx
@@ -1,6 +1,14 @@
 import { Dispatch, FormEvent, SetStateAction } from 'react';
 import { SearchIcon } from '@chakra-ui/icons';
-import { Box, BoxProps, CloseButton, Flex, Input } from '@chakra-ui/react';
+import {
+  Box,
+  BoxProps,
+  CloseButton,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  Input,
+} from '@chakra-ui/react';
 import { DEFAULT_PAGE_PADDING } from '@/constants/style';
 
 // TODO : Input 컴포넌트인데 BoxProps를 받아오니깐 어색... 새로운 작명이 필요
@@ -19,28 +27,33 @@ const SearchInput = ({
   ...props
 }: SearchInputProps) => {
   return (
-    <Box p={`0 ${DEFAULT_PAGE_PADDING}`} {...props}>
-      <Flex
-        padding="8px 16px"
-        bg="gray.200"
-        borderRadius="10px"
-        alignItems="center"
-      >
-        <SearchIcon boxSize={6} />
-        <form style={{ flexGrow: '1' }} onSubmit={(e) => onSearchSubmit(e)}>
-          <Input
-            fontSize="1.4rem"
-            color="gray.700"
-            disabled={disabled}
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            placeholder="검색어를 입력하세요."
-            focusBorderColor="transparent"
-          />
-        </form>
-        <CloseButton onClick={() => setKeyword('')} />
-      </Flex>
-    </Box>
+    <FormControl isInvalid={!keyword}>
+      <Box p={`0 ${DEFAULT_PAGE_PADDING}`} {...props}>
+        <Flex
+          padding="8px 16px"
+          bg="gray.200"
+          borderRadius="10px"
+          alignItems="center"
+        >
+          <SearchIcon mr="5px" boxSize={6} />
+          <form style={{ flexGrow: '1' }} onSubmit={(e) => onSearchSubmit(e)}>
+            <Input
+              fontSize="1.4rem"
+              color="gray.700"
+              disabled={disabled}
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              placeholder="검색어를 입력하세요."
+              focusBorderColor="transparent"
+            />
+          </form>
+          <CloseButton ml="5px" onClick={() => setKeyword('')} />
+        </Flex>
+        {!keyword && (
+          <FormErrorMessage>검색어를 입력해주세요.</FormErrorMessage>
+        )}
+      </Box>
+    </FormControl>
   );
 };
 

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -18,7 +18,7 @@ export interface SearchDataTypes {
 const SearchPage = () => {
   const { channelListData } = useChannelList();
 
-  const [option, setOption] = useState('');
+  const [option, setOption] = useState('유저');
   const [keyword, setKeyword] = useState('');
   const [searchData, setSearchData] = useState<SearchDataTypes>({
     keyword: '',
@@ -27,8 +27,8 @@ const SearchPage = () => {
 
   const onSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (option === '' || keyword === '') {
-      alert('검색 조건을 입력해주세요.');
+    if (keyword === '') {
+      alert('검색어를 입력해주세요.');
       return;
     }
 

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -55,7 +55,7 @@ const SearchPage = () => {
       <PageHeader pageName="검색" />
       <SearchPageBody>
         <OptionSelector
-          w="132px"
+          w="155px"
           mb="5px"
           option={option}
           setOption={setOption}

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -1,9 +1,6 @@
 import { FormEvent, useState } from 'react';
 import { Flex } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-// TODO : 게시판 목록을 API를 통해 '658b7460fadd1520147a8d72' 형태로 받아와서 객체 key-value 값으로 바꿀 필요가 있음.
-// 이에 따라 Router 설정도 필요 (with. 쿼리 스트링)
-// /constants/SearchOption 에서 수정하기
 import { OPTION_USER } from '@/constants/SearchOptions';
 import { DEFAULT_WIDTH } from '@/constants/style';
 import PageHeader from '@/components/PageHeader';
@@ -30,6 +27,11 @@ const SearchPage = () => {
 
   const onSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (option === '' || keyword === '') {
+      alert('검색 조건을 입력해주세요.');
+      return;
+    }
+
     if (option === OPTION_USER) {
       setSearchData({
         keyword,
@@ -43,9 +45,6 @@ const SearchPage = () => {
             (channel) => channel.name === option,
           )[0]._id,
         });
-      } else {
-        // TODO : Toast UI로 처리 필요
-        alert('네트워크 에러가 발생했습니다.');
       }
     }
     setKeyword('');
@@ -58,13 +57,13 @@ const SearchPage = () => {
         <OptionSelector
           w="132px"
           mb="5px"
+          option={option}
           setOption={setOption}
           channelListData={channelListData}
         />
         <SearchInput
           w="100%"
           mb="30px"
-          disabled={option ? false : true}
           keyword={keyword}
           setKeyword={setKeyword}
           onSearchSubmit={onSearchSubmit}


### PR DESCRIPTION
## 작업 사항

- 검색 시 요청이 여러 번 들어가는 것을 막았습니다.
- 옵션 or 검색어를 입력하지 않고 enter키를 눌렀을 때 alert 창으로 경고를 띄웁니다.
- FormControl을 사용하여 옵션 or 검색어를 입력하지 않았을 때 isInvalid를 사용하여 사용자에게 눈에 띄도록 처리해봤습니다.

## 관련 이슈

#86 

## PR Point

- SearchPage에서는 채널 옵션을 불러오는 것을 제외하면 따로 query문을 사용하는 것이 없어 react-hook-form은 도입하지 않았습니다.
- 미처 확인 못한 경우가 있는지 알려주시면 바로 반영하겠습니다.

## 참고사항
