### PR TITLE
[Fix] MyCommentList 페이지 기능 추가 및 UserContentBlock 컴포넌트 기능 개선

### DIFF
--- a/src/components/common/UserContentBlock/index.tsx
+++ b/src/components/common/UserContentBlock/index.tsx
@@ -19,6 +19,7 @@ interface UserContentBlockProps extends FlexProps {
   ellipsis?: number | number[];
   subContent?: string;
   contentFontSize?: string | number;
+  onContentClick?: () => void;
   onImageClick?: () => void;
   onSubContentClick?: () => void;
 }
@@ -33,6 +34,7 @@ const UserContentBlock = ({
   ellipsis = 1,
   subContent,
   contentFontSize = '1.2rem',
+  onContentClick,
   onSubContentClick,
   onImageClick,
   ...props
@@ -42,9 +44,10 @@ const UserContentBlock = ({
       w={DEFAULT_WIDTH}
       align="center"
       gap="17px"
-      cursor="pointer"
+      cursor={onContentClick && 'pointer'}
       pl={DEFAULT_PAGE_PADDING}
       pr={DEFAULT_PAGE_PADDING}
+      onClick={() => onContentClick && onContentClick()}
       {...props}
     >
       <Avatar
@@ -85,7 +88,10 @@ const UserContentBlock = ({
             right="0"
             zIndex="normal"
             cursor={onSubContentClick && 'pointer'}
-            onClick={() => onSubContentClick && onSubContentClick()}
+            onClick={(event) => {
+              event.stopPropagation();
+              onSubContentClick && onSubContentClick();
+            }}
           >
             {subContent}
           </Text>

--- a/src/components/common/UserContentBlock/index.tsx
+++ b/src/components/common/UserContentBlock/index.tsx
@@ -19,7 +19,6 @@ interface UserContentBlockProps extends FlexProps {
   ellipsis?: number | number[];
   subContent?: string;
   contentFontSize?: string | number;
-  onContentClick?: () => void;
   onImageClick?: () => void;
   onSubContentClick?: () => void;
 }
@@ -34,7 +33,6 @@ const UserContentBlock = ({
   ellipsis = 1,
   subContent,
   contentFontSize = '1.2rem',
-  onContentClick,
   onSubContentClick,
   onImageClick,
   ...props
@@ -44,10 +42,9 @@ const UserContentBlock = ({
       w={DEFAULT_WIDTH}
       align="center"
       gap="17px"
-      cursor={onContentClick && 'pointer'}
+      cursor="pointer"
       pl={DEFAULT_PAGE_PADDING}
       pr={DEFAULT_PAGE_PADDING}
-      onClick={() => onContentClick && onContentClick()}
       {...props}
     >
       <Avatar

--- a/src/pages/MyPage/MyCommentList/MyCommentListItem.tsx
+++ b/src/pages/MyPage/MyCommentList/MyCommentListItem.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ListItem, Box, Text } from '@chakra-ui/react';
 import { useDeleteComment } from '@/hooks/useComment';
+import { usePostDetail } from '@/hooks/usePost';
+import { calculateTimeDiff } from '@/utils/calculateTimeDiff';
 import UserContentBlock from '@/components/common/UserContentBlock';
 import Confirm from '@/components/common/Confirm';
-import { calculateTimeDiff } from '@/utils/calculateTimeDiff';
+
 interface MyCommentListItemProps {
   id: string;
   image: string;
+  postId: string;
   username: string;
   comment: string;
   createdAt: string;
@@ -16,12 +20,14 @@ interface MyCommentListItemProps {
 const MyCommentListItem = ({
   id,
   image,
+  postId,
   username,
   comment,
   createdAt,
   lineClamp = 1,
 }: MyCommentListItemProps) => {
   const [isConfirm, setIsConfirm] = useState(false);
+  const navigate = useNavigate();
   const deleteCommentMutate = useDeleteComment();
 
   const onConfirm = () => {
@@ -33,21 +39,41 @@ const MyCommentListItem = ({
     setIsConfirm(false);
   };
 
+  const { data: myPost } = usePostDetail({ id: postId });
+
+  const onMoveMyComment = (id: string, channel: string) => {
+    switch (channel) {
+      case 'free':
+        navigate(`/board/free/${id}`);
+        break;
+      case 'reflection':
+        navigate(`/board/reflection/${id}`);
+        break;
+      case 'infoshare':
+        navigate(`/board/infoshare/${id}`);
+        break;
+    }
+  };
+
   return (
     <ListItem key={id} p="10px 0 10px" borderBottom="1px solid #D9D9D9">
       <UserContentBlock
         p="0"
         w="100%"
-        cursor="default"
         userImage={image}
         userImageSize="40px"
         username={username}
         isOnline={false}
         content={calculateTimeDiff(createdAt) || ''}
         subContent="삭제"
+        onContentClick={() => onMoveMyComment(postId, myPost.channel?.name)}
         onSubContentClick={() => setIsConfirm(true)}
       />
-      <Box mt="10px">
+      <Box
+        pt="10px"
+        cursor="pointer"
+        onClick={() => onMoveMyComment(postId, myPost.channel?.name)}
+      >
         <Text noOfLines={lineClamp} fontSize="1.3rem">
           {comment}
         </Text>

--- a/src/pages/MyPage/MyCommentList/MyCommentListItem.tsx
+++ b/src/pages/MyPage/MyCommentList/MyCommentListItem.tsx
@@ -66,7 +66,7 @@ const MyCommentListItem = ({
         isOnline={false}
         content={calculateTimeDiff(createdAt) || ''}
         subContent="삭제"
-        onContentClick={() => onMoveMyComment(postId, myPost.channel?.name)}
+        onClick={() => onMoveMyComment(postId, myPost.channel?.name)}
         onSubContentClick={() => setIsConfirm(true)}
       />
       <Box

--- a/src/pages/MyPage/MyCommentList/index.tsx
+++ b/src/pages/MyPage/MyCommentList/index.tsx
@@ -26,10 +26,11 @@ const MyCommentList = () => {
               작성한 댓글이 없습니다.
             </Box>
           )}
-          {myCommentList.map(({ _id, comment, createdAt }) => (
+          {myCommentList.map(({ _id, comment, createdAt, post }) => (
             <MyCommentListItem
               key={_id}
               id={_id}
+              postId={post}
               comment={comment}
               image={image}
               username={username}


### PR DESCRIPTION
## 작업 사항
- MyCommentList 페이지에서 댓글을 클릭하면 댓글을 작성한 게시글로 이동합니다.
- 삭제 버튼을 누르면 삭제에 대한 이벤트 기능만 동작하도록 했습니다. (이벤트 전파 방지 코드 추가)
- UserContentBlock 컴포넌트 내부에 이벤트 추가했습니다. (전체 영역에 이벤트 걸 수 있는 코드 추가)
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#158 
<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point
- 내가 작성한 댓글 페이지에서 댓글 클릭하면 댓글이 작성된 게시글로 이동시켰습니다.
- UserContentBlock 컴포넌트 이벤트 추가 및 서브 이벤트에 이벤트 전파 방지 코드 추가했습니다.
<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->
