### PR TITLE
[Fix] MainPage Grass 컴포넌트 오류 해결 - 로그인 시 잔디 출력이 안되는 이슈

### DIFF
--- a/src/constants/GrassDummy.ts
+++ b/src/constants/GrassDummy.ts
@@ -1,18 +1,21 @@
+const today = new Date();
+const currentMonth = (today.getMonth() + 1).toString().padStart(2, '0');
+
 export const GRASS_DUMMY = [
   {
     time: '01:00:00',
-    createdAt: '2024-01-12T07:58:20.808Z',
+    createdAt: `2024-${currentMonth}-12T07:58:20.808Z`,
   },
   {
     time: '00:30:00',
-    createdAt: '2024-01-15T07:58:20.808Z',
+    createdAt: `2024-${currentMonth}-16T07:58:20.808Z`,
   },
   {
     time: '10:00:00',
-    createdAt: '2024-01-27T07:58:20.808Z',
+    createdAt: `2024-${currentMonth}-27T07:58:20.808Z`,
   },
   {
     time: '00:00:30',
-    createdAt: '2024-01-01T07:58:20.808Z',
+    createdAt: `2024-${currentMonth}-01T07:58:20.808Z`,
   },
 ];

--- a/src/pages/MainPage/GuestGrassBox.tsx
+++ b/src/pages/MainPage/GuestGrassBox.tsx
@@ -1,0 +1,16 @@
+import Grass from '@/components/Grass';
+import { GRASS_DUMMY } from '@/constants/GrassDummy';
+import { Text } from '@chakra-ui/react';
+
+const GuestGrassBox = () => {
+  return (
+    <>
+      <Text fontSize="1.5rem" fontWeight="bold" color="black" mb="17px">
+        여러분의 열정을 기록해 보세요.
+      </Text>
+      <Grass timerPosts={GRASS_DUMMY} />
+    </>
+  );
+};
+
+export default GuestGrassBox;

--- a/src/pages/MainPage/LoginGrassBox.tsx
+++ b/src/pages/MainPage/LoginGrassBox.tsx
@@ -1,0 +1,29 @@
+import { User } from '@/apis/type';
+import Grass from '@/components/Grass';
+import { GRASS_DUMMY } from '@/constants/GrassDummy';
+import { useStudyPost } from '@/hooks/useStudy';
+
+interface LoginGrassBoxProps {
+  myInfo: User;
+}
+
+const LoginGrassBox = ({ myInfo }: LoginGrassBoxProps) => {
+  const timerChannelId = JSON.parse(myInfo.fullName).timerChannelId;
+  const { studyPost = [] } = useStudyPost({
+    channelId: timerChannelId,
+  });
+  const studyPosts = myInfo
+    ? studyPost.map(({ title, createdAt }) => ({
+        time: title,
+        createdAt,
+      }))
+    : GRASS_DUMMY;
+
+  return (
+    <>
+      <Grass timerPosts={studyPosts} />
+    </>
+  );
+};
+
+export default LoginGrassBox;

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import { DEFAULT_PAGE_PADDING } from '@/constants/style';
 import { useMyInfo } from '@/hooks/useAuth';
@@ -8,24 +8,11 @@ import GuestProfile from '@/pages/MainPage/GuestProfile';
 import LoginProfile from '@/pages/MainPage/LoginProfile';
 import Dday from '@/pages/MainPage/Dday';
 import BoardListPreview from '@/pages/MainPage/BoardListPreview';
-import { useStudyPost } from '@/hooks/useStudy';
-import Grass from '@/components/Grass';
-import { GRASS_DUMMY } from '@/constants/GrassDummy';
+import LoginGrassBox from '@/pages/MainPage/LoginGrassBox';
+import GuestGrassBox from '@/pages/MainPage/GuestGrassBox';
 
 const MainPage = () => {
   const { data: myInfo } = useMyInfo();
-
-  const timerChannelId = myInfo && JSON.parse(myInfo.fullName).timerChannelId;
-  const { studyPost = [] } = useStudyPost({
-    channelId: timerChannelId,
-  });
-
-  const studyPosts = myInfo
-    ? studyPost.map(({ title, createdAt }) => ({
-        time: title,
-        createdAt,
-      }))
-    : GRASS_DUMMY;
 
   return (
     <>
@@ -40,12 +27,7 @@ const MainPage = () => {
         <MainPageBody>
           {myInfo ? <LoginProfile myInfo={myInfo} /> : <GuestProfile />}
           <Dday myInfo={myInfo} />
-          {!myInfo && (
-            <Text fontSize="1.5rem" fontWeight="bold" color="black" mb="17px">
-              여러분의 열정을 기록해 보세요.
-            </Text>
-          )}
-          <Grass timerPosts={studyPosts} />
+          {!myInfo ? <GuestGrassBox /> : <LoginGrassBox myInfo={myInfo} />}
           <BoardListPreview />
         </MainPageBody>
         <Footer position="sticky" bottom="0" />


### PR DESCRIPTION
## 작업 사항

- 로그인을 하고 바로 메인페이지로 갔을 때 잔디 내역이 안 뜨는 오류를 수정했습니다.

## 관련 이슈

#147 

## PR Point

- myInfo의 유무에 따른 분기가 필요해서 `GuestGrassBox`, `LoginGrassBox` 컴포넌트를 분리하였습니다.

## 참고사항

- 발견하지 못한 오류가 있다면 말씀 부탁드리겠습니다 !
