### PR TITLE
[Fix] 회고인증 게시판 글 보이게 수정

### DIFF
--- a/src/pages/ReflectionPostEditPage/index.tsx
+++ b/src/pages/ReflectionPostEditPage/index.tsx
@@ -1,5 +1,6 @@
 import PageHeader from '@/components/PageHeader';
 import { DEFAULT_HEADER_HEIGHT } from '@/constants/style';
+import { useChannelInfo } from '@/hooks/useChannels';
 import { useEditPost, usePostDetail, usePosting } from '@/hooks/usePost';
 import { getRecentEightDates } from '@/utils/getRecentEightDates';
 import { EditIcon } from '@chakra-ui/icons';
@@ -118,6 +119,10 @@ const ReflectionPostEditPage = () => {
     enabled: !!postId,
   });
 
+  const { channel: reflectionChannel } = useChannelInfo({
+    channelInfo: 'reflection',
+  });
+
   const {
     register,
     handleSubmit,
@@ -163,11 +168,10 @@ const ReflectionPostEditPage = () => {
       onEditPost({
         postId,
         title,
-        //존재하는 게시판이름과 id 1대1 대응하는 자료구조가 있으면 좋을것 같습니다. 일단 임시로 가져와 넣어두었습니다
-        channelId: '659f893e93c1183c6d54ac9c',
+        channelId: reflectionChannel._id,
       });
     } else {
-      onCreatePost({ title, channelId: '659f893e93c1183c6d54ac9c' });
+      onCreatePost({ title, channelId: reflectionChannel._id });
     }
   };
 


### PR DESCRIPTION
## 작업 사항

- 회고 인증 게시판의 channelId를 하드코딩해서 사용하던 부분을 초기화 이후 동적으로 id받아와서 사용하게 수정
- useChannelInfo훅을 사용하였습니다

## 관련 이슈

<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point

<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->

## 참고사항
