### PR TITLE
[Feature] 회원 상세 정보 페이지 (팔로우, 팔로워 페이지 추가)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,7 +59,7 @@ const App = () => {
               <Route path="/notification" element={<NotificationPage />} />
               <Route path="/timer" element={<TimerPage />} />
             </Route>
-            <Route path="/:username" element={<UserInfo />} />
+            <Route path="/:username/*" element={<UserInfo />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/board" element={<BoardEnterPage />} />
             <Route

--- a/src/pages/MyPage/MyCommentList/index.tsx
+++ b/src/pages/MyPage/MyCommentList/index.tsx
@@ -22,7 +22,7 @@ const MyCommentList = () => {
       <CommentListContainer>
         <UnorderedList listStyleType="none" ml="0" p="20px">
           {myCommentList.length === 0 && (
-            <Box textAlign="center" fontSize="14px" p="50px 0">
+            <Box textAlign="center" fontSize="1.4rem" p="50px 0">
               작성한 댓글이 없습니다.
             </Box>
           )}

--- a/src/pages/UserInfo/Follower/index.tsx
+++ b/src/pages/UserInfo/Follower/index.tsx
@@ -1,0 +1,65 @@
+import { useNavigate } from 'react-router-dom';
+import { Follow, User } from '@/apis/type';
+import UserListItem from '@/components/UserList/UserListItem';
+import { useGetUsersList } from '@/hooks/useUser';
+import { Box, UnorderedList } from '@chakra-ui/react';
+import { useMyInfo } from '@/hooks/useAuth';
+
+interface FollowerProps {
+  userInfo: User;
+  isFollowing: boolean;
+  isSameUser: boolean;
+}
+
+const Follower = ({ userInfo, isFollowing, isSameUser }: FollowerProps) => {
+  const navigate = useNavigate();
+  const { data: myInfo } = useMyInfo();
+  const { data: userList = [] } = useGetUsersList({});
+  const followers = isSameUser
+    ? (userInfo.followers as Follow[]).map((follow) => follow._id)
+    : userInfo.followers;
+  if (!myInfo) {
+    return;
+  }
+
+  return (
+    <Box>
+      <UnorderedList>
+        {isFollowing && (
+          <UserListItem
+            userImage={myInfo.image}
+            username={myInfo.username}
+            onClick={() => navigate(`/${myInfo.username}`)}
+          />
+        )}
+        {userList.map((user) => {
+          const following = user.following;
+          const isFollowing = following.some((follow) => {
+            if (typeof follow === 'string') {
+              return followers.includes(follow);
+            }
+          });
+          if (isFollowing) {
+            return (
+              <UserListItem
+                key={user._id}
+                userImage={user.image}
+                username={user.username}
+                onClick={() => navigate(`/${user.username}`)}
+              />
+            );
+          }
+        })}
+        {!isFollowing && followers.length === 0 ? (
+          <Box textAlign="center" fontSize="1.4rem" p="50px 0">
+            팔로워한 유저가 없습니다.
+          </Box>
+        ) : (
+          ''
+        )}
+      </UnorderedList>
+    </Box>
+  );
+};
+
+export default Follower;

--- a/src/pages/UserInfo/Following/index.tsx
+++ b/src/pages/UserInfo/Following/index.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from 'react-router-dom';
+import { Follow, User } from '@/apis/type';
+import UserListItem from '@/components/UserList/UserListItem';
+import { useGetUsersList } from '@/hooks/useUser';
+import { Box, UnorderedList } from '@chakra-ui/react';
+import { useMyInfo } from '@/hooks/useAuth';
+
+interface FollowProps {
+  userInfo: User;
+  isSameUser: boolean;
+}
+
+type ModifiedUser = Omit<User, 'followers'> & Partial<{ followers: Follow[] }>;
+
+const Following = ({ userInfo, isSameUser }: FollowProps) => {
+  const navigate = useNavigate();
+  const { data: myInfo } = useMyInfo();
+  const { data: userList = [] } = useGetUsersList({});
+  const follow = isSameUser
+    ? (userInfo.following as Follow[]).map((follow) => follow._id)
+    : userInfo.following;
+  if (!myInfo) {
+    return;
+  }
+
+  const myFollowers = myInfo.followers.map((user: ModifiedUser) => user._id);
+  const isFollowCheck = follow.some((user) => {
+    if (typeof user === 'string') {
+      return myFollowers.includes(user);
+    }
+  });
+
+  return (
+    <Box>
+      <UnorderedList>
+        {isFollowCheck && (
+          <UserListItem
+            userImage={myInfo.image}
+            username={myInfo.username}
+            onClick={() => navigate(`/${myInfo.username}`)}
+          />
+        )}
+        {userList.map((user) => {
+          const { followers } = user;
+          const isFollowing = followers.some((follower) => {
+            if (typeof follower === 'string') {
+              return follow.includes(follower);
+            }
+          });
+          if (isFollowing) {
+            return (
+              <UserListItem
+                key={user._id}
+                userImage={user.image}
+                username={user.username}
+                onClick={() => navigate(`/${user.username}`)}
+              />
+            );
+          }
+        })}
+        {!isFollowCheck && follow.length === 0 ? (
+          <Box textAlign="center" fontSize="1.4rem" p="50px 0">
+            팔로우한 유저가 없습니다.
+          </Box>
+        ) : (
+          ''
+        )}
+      </UnorderedList>
+    </Box>
+  );
+};
+
+export default Following;

--- a/src/pages/UserInfo/UserFollowInfo.tsx
+++ b/src/pages/UserInfo/UserFollowInfo.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Flex, Box, Text } from '@chakra-ui/react';
 import { useStudyPost } from '@/hooks/useStudy';
 import { User } from '@/apis/type';
@@ -7,6 +8,7 @@ interface UserFollowInfoProps {
 }
 
 const UserFollowInfo = ({ followInfo }: UserFollowInfoProps) => {
+  const navigate = useNavigate();
   const { followers, following, fullName } = followInfo;
 
   const { timerChannelId } = JSON.parse(fullName);
@@ -21,11 +23,23 @@ const UserFollowInfo = ({ followInfo }: UserFollowInfoProps) => {
       borderTop="1px solid #D9D9D9"
       padding="8px 0"
     >
-      <Box fontSize="1.4rem" textAlign="center" flex="1">
+      <Box
+        fontSize="1.4rem"
+        textAlign="center"
+        flex="1"
+        cursor="pointer"
+        onClick={() => navigate('./follower')}
+      >
         <Text>팔로워</Text>
         <Text as="strong">{followers.length}</Text>
       </Box>
-      <Box fontSize="1.4rem" textAlign="center" flex="1">
+      <Box
+        fontSize="1.4rem"
+        textAlign="center"
+        flex="1"
+        cursor="pointer"
+        onClick={() => navigate('./follow')}
+      >
         <Text>팔로우</Text>
         <Text as="strong">{following.length}</Text>
       </Box>

--- a/src/pages/UserInfo/UserInfoContainer.tsx
+++ b/src/pages/UserInfo/UserInfoContainer.tsx
@@ -1,8 +1,12 @@
+import { Route, Routes } from 'react-router-dom';
 import { Box } from '@chakra-ui/react';
 import { User } from '@/apis/type';
 import UserProfile from './UserProfile';
 import UserFollowInfo from './UserFollowInfo';
 import UserGrass from './UserGrass';
+import Following from './Following';
+import Follower from './Follower';
+import { useEffect, useState } from 'react';
 
 interface UserInfoContainerProps {
   userList: User[];
@@ -17,18 +21,69 @@ const UserInfoContainer = ({
   isSameUser,
   username,
 }: UserInfoContainerProps) => {
-  const userInfo = userList.filter((user) => user.username === username)[0];
+  const [isFollowing, setIsFollowing] = useState(false);
+  const userInfo =
+    userList.filter((user) => user.username === username)[0] ?? myInfo;
+
+  const [followId, setFollowId] = useState('');
+
+  const { image, _id: userId } = userInfo;
+  const { following } = myInfo;
+
+  useEffect(() => {
+    const isAlreadyFollowing = following.some(
+      ({ user: followingUserId, _id }) => {
+        if (followingUserId === userId) {
+          setFollowId(_id);
+          return true;
+        }
+      },
+    );
+    onupdateFollowing(isAlreadyFollowing);
+  }, [userInfo]);
+
+  const onupdateFollowing = (isFollowing: boolean) => {
+    setIsFollowing(isFollowing);
+  };
 
   return (
     <Box padding="25px 0">
-      <UserProfile
-        userInfo={userInfo ?? myInfo}
-        myInfo={myInfo}
-        username={username}
-        isSameUser={isSameUser}
-      />
-      <UserFollowInfo followInfo={userInfo ?? myInfo} />
-      <UserGrass userInfo={userInfo ?? myInfo} />
+      <Routes>
+        <Route
+          path="follow"
+          element={
+            <Following userInfo={userInfo ?? myInfo} isSameUser={isSameUser} />
+          }
+        />
+        <Route
+          path="follower"
+          element={
+            <Follower
+              userInfo={userInfo ?? myInfo}
+              isFollowing={isFollowing}
+              isSameUser={isSameUser}
+            />
+          }
+        />
+        <Route
+          path="/*"
+          element={
+            <>
+              <UserProfile
+                image={image}
+                userId={userId}
+                followId={followId}
+                username={username}
+                isSameUser={isSameUser}
+                isFollowing={isFollowing}
+                onupdateFollowing={onupdateFollowing}
+              />
+              <UserFollowInfo followInfo={userInfo ?? myInfo} />
+              <UserGrass userInfo={userInfo ?? myInfo} />
+            </>
+          }
+        />
+      </Routes>
     </Box>
   );
 };

--- a/src/pages/UserInfo/UserProfile.tsx
+++ b/src/pages/UserInfo/UserProfile.tsx
@@ -1,43 +1,25 @@
-import { useEffect, useState } from 'react';
 import { Flex, Box, Text, Avatar } from '@chakra-ui/react';
-import { User } from '@/apis/type';
 import UserProfileButton from './UserProfileButton';
 
 interface UserProfileProps {
-  userInfo: User;
-  myInfo: User;
   username: string;
   isSameUser: boolean;
+  isFollowing: boolean;
+  image: string;
+  followId: string;
+  userId: string;
+  onupdateFollowing: (isFollowing: boolean) => void;
 }
 
 const UserProfile = ({
-  userInfo,
-  myInfo,
   username,
   isSameUser,
+  isFollowing,
+  image,
+  followId,
+  userId,
+  onupdateFollowing,
 }: UserProfileProps) => {
-  const [isFollowing, setIsFollowing] = useState(false);
-  const [followId, setFollowId] = useState('');
-
-  const { image, _id: userId } = userInfo;
-  const { following } = myInfo;
-
-  useEffect(() => {
-    const isAlreadyFollowing = following.some(
-      ({ user: followingUserId, _id }) => {
-        if (followingUserId === userId) {
-          setFollowId(_id);
-          return followingUserId === userId;
-        }
-      },
-    );
-    setIsFollowing(isAlreadyFollowing);
-  }, [following]);
-
-  const onupdateFollowing = (isFollowing: boolean) => {
-    setIsFollowing(isFollowing);
-  };
-
   return (
     <Flex alignItems="center" p="0 20px" mb="30px">
       <Box mr="15px">


### PR DESCRIPTION
## 작업 사항
- 회원을 팔로워한 유저 목록 페이지 제작 추가
- 회원이 팔로우한 유저 목록 페이지 제작
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#198 
<!-- 관련 이슈 번호(#00)를 적어주세요 -->

## PR Point
- 팔로워, 팔로우 한 페이지의 로직이 비슷해서 하나의 함수로 만들고 싶었는데, 데이터가 일괄되게 전달되지 않다 보니.. 급한 대로 다른 페이지로 만들었습니다.. 좋은 의견 있으시면 제안해 주시면 감사드리겠습니다.
- Route(UserInfo) 페이지 내에 또 다른 Routes를 만들어서 Route로 내부에서 페이지를 이동하도록 작업했는데 적절한지 궁금합니다. 이유는 이미 계산된 데이터가 있는데 다시 api를 호출해서 계산하는 것보다 props로 데이터를 내려주는 것이 적절하다고 판단했습니다.
<!-- 중점적으로 코드리뷰를 받고 싶은 사항을 적어주세요 -->

## 참고사항
- `apitypes`의 `User`의 `followers`, `following` 프로퍼티를 유니온 타입으로 설정하면 해당 타입을 사용하는 다른 페이지에 이상이 갈 수 있어 페이지 내에 타입을 지정하여 사용했습니다.
- 검색 기능도 추가할 예정입니다.