### PR TITLE
🐛 MessageList profile Image 안나오는 문제 수정(전달 받는 데이터의 key값을 다르게 받고 있었습니다.)

### DIFF
--- a/src/hooks/useMessageList.ts
+++ b/src/hooks/useMessageList.ts
@@ -24,7 +24,7 @@ export const useMessageList = () => {
 
       return {
         key: createdAt,
-        userImage: otherType.coverImage,
+        userImage: otherType.image,
         username: otherType.username,
         content: message,
         subContent: calculateTimeDiff(createdAt) || '',


### PR DESCRIPTION
## 작업 사항
- useMessageList hook에서 전달된 userImage 데이터 수정했습니다.(profile 이미지는 image인데 coverimage를 반환하고 있었습니다.)
<!-- 작업한 내용을 적어주세요 -->

## 관련 이슈
#200 
<!-- 관련 이슈 번호(#00)를 적어주세요 -->
